### PR TITLE
switch to go1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/codegen.go
+++ b/codegen.go
@@ -47,11 +47,11 @@ func Generate2d3dTemplate(name string, checkNoChange bool) {
 	inPath := filepath.Join("templates", name+".template")
 	tmpl := template.New("")
 	tmpl.Funcs(template.FuncMap{
-		"mkargs": func(base map[string]interface{}, vs ...string) (map[string]interface{}, error) {
+		"mkargs": func(base map[string]any, vs ...string) (map[string]any, error) {
 			if len(vs)%2 != 0 {
 				return nil, errors.New("mismatched keys and values")
 			}
-			res := map[string]interface{}{}
+			res := map[string]any{}
 			for k, v := range base {
 				res[k] = v
 			}
@@ -93,7 +93,7 @@ func Generate2d3dTemplate(name string, checkNoChange bool) {
 	}
 }
 
-func TemplateEnvironment(pkg string) map[string]interface{} {
+func TemplateEnvironment(pkg string) map[string]any {
 	coordType := "Coord"
 	matrixType := "Matrix2"
 	faceType := "Segment"
@@ -112,7 +112,7 @@ func TemplateEnvironment(pkg string) map[string]interface{} {
 		circleLetter = "s"
 		numDims = 3
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"package":      pkg,
 		"model2d":      pkg == "model2d",
 		"coordType":    coordType,
@@ -126,7 +126,7 @@ func TemplateEnvironment(pkg string) map[string]interface{} {
 	}
 }
 
-func RenderTemplate(template *template.Template, data interface{}) string {
+func RenderTemplate(template *template.Template, data any) string {
 	w := bytes.NewBuffer(nil)
 	essentials.Must(template.Execute(w, data))
 	return string(w.Bytes())

--- a/examples/decoration/zigzag_egg/main.go
+++ b/examples/decoration/zigzag_egg/main.go
@@ -152,7 +152,7 @@ func CreateZigZag() model3d.Solid {
 	}
 	zigZagMesh.AddMesh(zigZagMesh.MapCoords(model2d.XY(-1, 1).Mul))
 	bg := model2d.BoundsRect(zigZagMesh)
-	model2d.RasterizeColor("zig_zag.png", []interface{}{
+	model2d.RasterizeColor("zig_zag.png", []any{
 		bg, outerMesh, innerMesh, zigZagMesh,
 	}, []color.Color{
 		color.Gray{Y: 0xff},

--- a/examples/experiments/smooth_bezier/main.go
+++ b/examples/experiments/smooth_bezier/main.go
@@ -83,7 +83,7 @@ func main() {
 
 func RenderSequence(animationPath string, upsampleRate float64, size model2d.Coord,
 	mesh *model2d.Mesh, beziers []model2d.BezierCurve) {
-	rasterizeObj := func(obj interface{}, thickness float64) *image.Gray {
+	rasterizeObj := func(obj any, thickness float64) *image.Gray {
 		rast := &model2d.Rasterizer{
 			Scale:     upsampleRate,
 			Bounds:    model2d.NewRect(model2d.Coord{}, size),

--- a/examples/parody/golden_gate/main.go
+++ b/examples/parody/golden_gate/main.go
@@ -279,7 +279,7 @@ func ColorFunc() toolbox3d.CoordColorFunc {
 	cables2 := createCablesAtX(cableXs()[1])
 	cableColor := pillarColor
 
-	coloredObjs := []interface{}{
+	coloredObjs := []any{
 		model3d.MarchingCubesSearch(pillars1, ColorMarchingDelta, 8),
 		pillarColor,
 		model3d.MarchingCubesSearch(pillars2, ColorMarchingDelta, 8),

--- a/examples/renderings/egg_2d/main.go
+++ b/examples/renderings/egg_2d/main.go
@@ -13,7 +13,7 @@ func main() {
 		return 0.9 + 0.1*math.Sin(theta*5)
 	}, 300)
 	circle := &model2d.Circle{Radius: 0.3}
-	objs := []interface{}{
+	objs := []any{
 		model2d.NewColliderSolid(model2d.MeshToCollider(egg)),
 		circle,
 	}

--- a/examples/renderings/rope_indent/main.go
+++ b/examples/renderings/rope_indent/main.go
@@ -115,7 +115,7 @@ func ConcurrentMapCoords(m *model3d.Mesh, f func(model3d.Coord3D) model3d.Coord3
 		newVertices[i] = f(vertices[i])
 	})
 
-	mapping := model3d.NewCoordToCoord()
+	mapping := model3d.NewCoordMap[model3d.Coord3D]()
 	for i, old := range vertices {
 		mapping.Store(old, newVertices[i])
 	}

--- a/examples/romantic/floral_arrangement/main.go
+++ b/examples/romantic/floral_arrangement/main.go
@@ -98,10 +98,10 @@ func CreateArrangement() []*FlowerDesc {
 	return results
 }
 
-func CompileArrangement(fs []*FlowerDesc) (model3d.Solid, map[*model3d.Mesh]interface{}) {
+func CompileArrangement(fs []*FlowerDesc) (model3d.Solid, map[*model3d.Mesh]any) {
 	solids := model3d.JoinedSolid{}
 	stemColor := render3d.NewColorRGB(55.0/255, 102.0/255, 54.0/255)
-	colorFuncs := map[*model3d.Mesh]interface{}{}
+	colorFuncs := map[*model3d.Mesh]any{}
 	for i, f := range fs {
 		log.Printf("Compiling flower %d/%d", i+1, len(fs))
 		stem := NewStem(model3d.XY(f.Base.X, f.Base.Y), f.Height, f.Flower.Tilt)

--- a/examples/romantic/heart_statue/main.go
+++ b/examples/romantic/heart_statue/main.go
@@ -91,7 +91,7 @@ func LoadLetter(filename string, x float64) model3d.Solid {
 }
 
 func NewColorFunc(colors map[model3d.Solid][3]float64) toolbox3d.CoordColorFunc {
-	var args []interface{}
+	var args []any
 	for solid, color := range colors {
 		mesh := model3d.MarchingCubesSearch(solid, MarchingDelta, 8)
 		args = append(args, mesh, render3d.NewColorRGB(color[0], color[1], color[2]))

--- a/examples/usable/penguin_calendar/body.go
+++ b/examples/usable/penguin_calendar/body.go
@@ -9,7 +9,7 @@ import (
 	"github.com/unixpickle/model3d/toolbox3d"
 )
 
-func PenguinBody() (obj model3d.Solid, colors []interface{}) {
+func PenguinBody() (obj model3d.Solid, colors []any) {
 	torso, torsoColor := PenguinTorso()
 	arms := PenguinArms()
 	eyes, eyesColor := PenguinEyes()
@@ -23,7 +23,7 @@ func PenguinBody() (obj model3d.Solid, colors []interface{}) {
 	beak = model3d.TransformSolid(xf, beak)
 	feet = model3d.TransformSolid(xf, feet)
 	fullSolid := (model3d.JoinedSolid{torso, arms, eyes, beak, feet}).Optimize()
-	return fullSolid, []interface{}{
+	return fullSolid, []any{
 		torso, torsoColor.Transform(xf),
 		eyes, eyesColor.Transform(xf),
 		arms, toolbox3d.ConstantCoordColorFunc(render3d.NewColor(0.1)),

--- a/examples/usable/penguin_calendar/text_block.go
+++ b/examples/usable/penguin_calendar/text_block.go
@@ -11,7 +11,7 @@ import (
 
 func CreateBlocks() {
 	joinedMesh := model3d.NewMesh()
-	colorMap := model3d.NewCoordToCoord()
+	colorMap := model3d.NewCoordMap[model3d.Coord3D]()
 
 	curX := 0.0
 	addBlock := func(block *model3d.Mesh, colorFunc toolbox3d.CoordColorFunc) {
@@ -73,7 +73,7 @@ func CreateBlocks() {
 func TextBlock(size model3d.Coord3D, inset float64, imgScale float64,
 	faces [6]string) (*model3d.Mesh, toolbox3d.CoordColorFunc) {
 	resMesh := model3d.NewMesh()
-	insideMap := model3d.NewCoordToBool()
+	insideMap := model3d.NewCoordMap[bool]()
 
 	for axis := 0; axis < 3; axis++ {
 		var origin model3d.Coord3D

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unixpickle/model3d
 
-go 1.14
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/model2d/bvh.go
+++ b/model2d/bvh.go
@@ -7,39 +7,42 @@ import (
 	"sort"
 )
 
-// GeneralBVH represents a (possibly unbalanced)
-// axis-aligned bounding box hierarchy.
+// BVH represents a (possibly unbalanced) axis-aligned
+// bounding box hierarchy.
 //
-// A GeneralBVH can store arbitrary Bounders.
-// For a mesh-specific version, see BVH.
-type GeneralBVH struct {
+// A BVH can be used to accelerate collision detection.
+// See BVHToCollider() for more details.
+//
+// A BVH node is either a leaf (a single Bounder), or a
+// branch with two or more children.
+type BVH[B Bounder] struct {
 	// Leaf, if non-nil, is the final bounder.
-	Leaf Bounder
+	Leaf B
 
 	// Branch, if Leaf is nil, points to two children.
-	Branch []*GeneralBVH
+	Branch []*BVH[B]
 }
 
-// NewGeneralBVHAreaDensity creates a GeneralBVH by
-// minimizing the product of each bounding box's perimeter with
+// NewBVHAreaDensity creates a BVH by minimizing
+// the product of each bounding box's perimeter with
 // the number of objects contained in the bounding box at
 // each branch.
 //
 // This is good for efficient ray collision detection.
-func NewGeneralBVHAreaDensity(objects []Bounder) *GeneralBVH {
-	return newGeneralBVH(sortBounders(objects), make([]float64, len(objects)),
-		areaDensityBVHSplit)
+func NewBVHAreaDensity[B Bounder](objects []B) *BVH[B] {
+	return newBVH(sortBounders(objects), make([]float64, len(objects)),
+		areaDensityBVHSplit[B])
 }
 
-func newGeneralBVH(sortedBounders [2][]*flaggedBounder, cache []float64,
-	splitter func([]*flaggedBounder, []float64) (int, float64)) *GeneralBVH {
+func newBVH[B Bounder](sortedBounders [2][]*flaggedBounder[B], cache []float64,
+	splitter func([]*flaggedBounder[B], []float64) (int, float64)) *BVH[B] {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 0 {
 		panic("empty sorted objects")
 	} else if numObjs == 1 {
-		return &GeneralBVH{Leaf: sortedBounders[0][0].B}
+		return &BVH[B]{Leaf: sortedBounders[0][0].B}
 	} else if numObjs == 2 {
-		return &GeneralBVH{Branch: []*GeneralBVH{
+		return &BVH[B]{Branch: []*BVH[B]{
 			{Leaf: sortedBounders[0][0].B},
 			{Leaf: sortedBounders[0][1].B},
 		}}
@@ -48,54 +51,18 @@ func newGeneralBVH(sortedBounders [2][]*flaggedBounder, cache []float64,
 	xIndex, xScore := splitter(sortedBounders[0], cache)
 	yIndex, yScore := splitter(sortedBounders[1], cache)
 
-	var split [2][2][]*flaggedBounder
+	var split [2][2][]*flaggedBounder[B]
 	if xScore < yScore {
 		split = splitBounders(sortedBounders, 0, xIndex)
 	} else {
 		split = splitBounders(sortedBounders, 1, yIndex)
 	}
-	return &GeneralBVH{
-		Branch: []*GeneralBVH{
-			newGeneralBVH(split[0], cache, splitter),
-			newGeneralBVH(split[1], cache, splitter),
+	return &BVH[B]{
+		Branch: []*BVH[B]{
+			newBVH(split[0], cache, splitter),
+			newBVH(split[1], cache, splitter),
 		},
 	}
-}
-
-// BVH represents a (possibly unbalanced) axis-aligned
-// bounding box hierarchy of segments.
-//
-// A BVH can be used to accelerate collision detection.
-// See BVHToCollider() for more details.
-//
-// A BVH node is either a leaf (a single segment), or a branch
-// with two or more children.
-//
-// For a more generic BVH that supports any object rather
-// than just segments, see GeneralBVH.
-type BVH struct {
-	// Leaf, if non-nil, is the sole object in this node.
-	Leaf *Segment
-
-	// Branch, if Leaf is nil, points to two children.
-	Branch []*BVH
-}
-
-// NewBVHAreaDensity is like NewGeneralBVHAreaDensity but
-// for segments.
-func NewBVHAreaDensity(objs []*Segment) *BVH {
-	return generalBVHToBVH(NewGeneralBVHAreaDensity(facesToBounders(objs)))
-}
-
-func generalBVHToBVH(g *GeneralBVH) *BVH {
-	if g.Leaf != nil {
-		return &BVH{Leaf: g.Leaf.(*Segment)}
-	}
-	res := &BVH{Branch: make([]*BVH, len(g.Branch))}
-	for i, g1 := range g.Branch {
-		res.Branch[i] = generalBVHToBVH(g1)
-	}
-	return res
 }
 
 // areaDensityBVHSplit chooses a split index that
@@ -106,7 +73,7 @@ func generalBVHToBVH(g *GeneralBVH) *BVH {
 // the number of segments.
 //
 // The cache must contain at least len(faces) entries.
-func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64) {
+func areaDensityBVHSplit[B Bounder](faces []*flaggedBounder[B], cache []float64) (int, float64) {
 	// Fill the cache with scores going in the other
 	// direction.
 	min, max := faces[len(faces)-1].Min, faces[len(faces)-1].Max
@@ -137,6 +104,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 
 // GroupSegments is like GroupBounders, but for segments
 // in particular.
+// This is now equivalent to GroupBounders(faces).
 //
 // This can be used to prepare models for being turned
 // into a collider efficiently, or for storing meshes in
@@ -145,11 +113,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 // The resulting hierarchy can be passed directly to
 // GroupedSegmentsToCollider().
 func GroupSegments(faces []*Segment) {
-	bs := facesToBounders(faces)
-	groupBounders(sortBounders(bs), bs)
-	for i, b := range bs {
-		faces[i] = b.(*Segment)
-	}
+	GroupBounders(faces)
 }
 
 // GroupBounders sorts a slice of objects into a balanced
@@ -161,11 +125,11 @@ func GroupSegments(faces []*Segment) {
 // To cut a slice in half, divide the length by two, round
 // down, and use the result as the start index for the
 // second half.
-func GroupBounders(objects []Bounder) {
+func GroupBounders[B Bounder](objects []B) {
 	groupBounders(sortBounders(objects), objects)
 }
 
-func groupBounders(sortedBounders [2][]*flaggedBounder, output []Bounder) {
+func groupBounders[B Bounder](sortedBounders [2][]*flaggedBounder[B], output []B) {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 2 {
 		// The area-based splitting criterion doesn't
@@ -188,12 +152,13 @@ func groupBounders(sortedBounders [2][]*flaggedBounder, output []Bounder) {
 	groupBounders(separated[1], output[midIdx:])
 }
 
-func splitBounders(sortedBounders [2][]*flaggedBounder, axis, midIdx int) [2][2][]*flaggedBounder {
+func splitBounders[B Bounder](sortedBounders [2][]*flaggedBounder[B],
+	axis, midIdx int) [2][2][]*flaggedBounder[B] {
 	for i, b := range sortedBounders[axis] {
 		b.Flag = i < midIdx
 	}
 
-	separated := [2][]*flaggedBounder{}
+	separated := [2][]*flaggedBounder[B]{}
 	separated[axis] = sortedBounders[axis]
 
 	numObjs := len(sortedBounders[0])
@@ -201,7 +166,7 @@ func splitBounders(sortedBounders [2][]*flaggedBounder, axis, midIdx int) [2][2]
 		if newAxis == axis {
 			continue
 		}
-		sep := make([]*flaggedBounder, numObjs)
+		sep := make([]*flaggedBounder[B], numObjs)
 		idx0 := 0
 		idx1 := midIdx
 		for _, b := range sortedBounders[newAxis] {
@@ -216,7 +181,7 @@ func splitBounders(sortedBounders [2][]*flaggedBounder, axis, midIdx int) [2][2]
 		separated[newAxis] = sep
 	}
 
-	return [2][2][]*flaggedBounder{
+	return [2][2][]*flaggedBounder[B]{
 		{
 			separated[0][:midIdx],
 			separated[1][:midIdx],
@@ -228,7 +193,7 @@ func splitBounders(sortedBounders [2][]*flaggedBounder, axis, midIdx int) [2][2]
 	}
 }
 
-func bestSplitAxis(sortedBounders [2][]*flaggedBounder) int {
+func bestSplitAxis[B Bounder](sortedBounders [2][]*flaggedBounder[B]) int {
 	midIdx := len(sortedBounders[0]) / 2
 
 	areaForAxis := func(axis int) float64 {
@@ -248,13 +213,13 @@ func bestSplitAxis(sortedBounders [2][]*flaggedBounder) int {
 	return axis
 }
 
-func sortBounders(bs []Bounder) [2][]*flaggedBounder {
+func sortBounders[B Bounder](bs []B) [2][]*flaggedBounder[B] {
 	// Allocate all of the flaggedBounders at once all
 	// next to each other in memory.
-	flagged := make([]flaggedBounder, len(bs))
+	flagged := make([]flaggedBounder[B], len(bs))
 	for i, b := range bs {
 		min, max := b.Min(), b.Max()
-		flagged[i] = flaggedBounder{
+		flagged[i] = flaggedBounder[B]{
 			B:   b,
 			Min: min,
 			Max: max,
@@ -262,9 +227,9 @@ func sortBounders(bs []Bounder) [2][]*flaggedBounder {
 		}
 	}
 
-	var result [2][]*flaggedBounder
+	var result [2][]*flaggedBounder[B]
 	for axis := range result {
-		bsCopy := make([]*flaggedBounder, len(flagged))
+		bsCopy := make([]*flaggedBounder[B], len(flagged))
 		for i := range flagged {
 			bsCopy[i] = &flagged[i]
 		}
@@ -283,7 +248,7 @@ func sortBounders(bs []Bounder) [2][]*flaggedBounder {
 	return result
 }
 
-func multipleBoundsArea(bs []*flaggedBounder) float64 {
+func multipleBoundsArea[B Bounder](bs []*flaggedBounder[B]) float64 {
 	min, max := bs[0].Min, bs[0].Max
 	for i := 1; i < len(bs); i++ {
 		b := bs[i]
@@ -314,8 +279,8 @@ func boundsArea(min, max Coord) float64 {
 	return 2 * (diff.X + diff.Y)
 }
 
-type flaggedBounder struct {
-	B    Bounder
+type flaggedBounder[B Bounder] struct {
+	B    B
 	Min  Coord
 	Max  Coord
 	Mid  Coord
@@ -371,12 +336,4 @@ func rayCollisionWithBounds(r *Ray, min, max Coord) (minFrac, maxFrac float64) {
 		}
 	}
 	return
-}
-
-func facesToBounders(faces []*Segment) []Bounder {
-	bs := make([]Bounder, len(faces))
-	for i, t := range faces {
-		bs[i] = t
-	}
-	return bs
 }

--- a/model2d/collisions.go
+++ b/model2d/collisions.go
@@ -22,7 +22,7 @@ type RayCollision struct {
 
 	// Extra contains additional, implementation-specific
 	// information about the collision.
-	Extra interface{}
+	Extra any
 }
 
 // A Collider is the outline of a 2-dimensional shape.
@@ -120,6 +120,19 @@ func GroupedSegmentsToCollider(segs []*Segment) MultiCollider {
 		c2 := GroupedSegmentsToCollider(segs[mid:])
 		return &joinedMultiCollider{NewJoinedCollider([]Collider{c1, c2})}
 	}
+}
+
+// BVHToCollider converts a BVH into a MultiCollider in a
+// hierarchical way.
+func BVHToCollider(b *BVH[*Segment]) MultiCollider {
+	if b.Leaf != nil {
+		return b.Leaf
+	}
+	other := make([]Collider, len(b.Branch))
+	for i, b1 := range b.Branch {
+		other[i] = BVHToCollider(b1)
+	}
+	return joinedMultiCollider{NewJoinedCollider(other)}
 }
 
 ////////////////////////////////////////////////////////////

--- a/model2d/fast_maps.go
+++ b/model2d/fast_maps.go
@@ -2,24 +2,30 @@
 
 package model2d
 
+type Adder interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~complex64 | ~complex128
+}
+
 // CoordMap implements a map-like interface for
-// mapping Coord to any.
+// mapping Coord to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordMap struct {
-	slowMap map[Coord]any
-	fastMap map[uint64]cellForCoordMap
+type CoordMap[T any] struct {
+	slowMap map[Coord]T
+	fastMap map[uint64]cellForCoordMap[T]
 }
 
 // NewCoordMap creates an empty map.
-func NewCoordMap() *CoordMap {
-	return &CoordMap{fastMap: map[uint64]cellForCoordMap{}}
+func NewCoordMap[T any]() *CoordMap[T] {
+	return &CoordMap[T]{fastMap: map[uint64]cellForCoordMap[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordMap) Len() int {
+func (m *CoordMap[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -29,7 +35,7 @@ func (m *CoordMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordMap) Value(key Coord) any {
+func (m *CoordMap[T]) Value(key Coord) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -39,11 +45,11 @@ func (m *CoordMap) Value(key Coord) any {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordMap) Load(key Coord) (any, bool) {
+func (m *CoordMap[T]) Load(key Coord) (T, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForCoordMap(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForCoordMap[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -54,7 +60,7 @@ func (m *CoordMap) Load(key Coord) (any, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordMap) Delete(key Coord) {
+func (m *CoordMap[T]) Delete(key Coord) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
@@ -67,7 +73,7 @@ func (m *CoordMap) Delete(key Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordMap) Store(key Coord, value any) {
+func (m *CoordMap[T]) Store(key Coord, value T) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		cell, ok := m.fastMap[hash]
@@ -76,7 +82,7 @@ func (m *CoordMap) Store(key Coord, value any) {
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordMap{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordMap[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -85,7 +91,7 @@ func (m *CoordMap) Store(key Coord, value any) {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordMap) KeyRange(f func(key Coord) bool) {
+func (m *CoordMap[T]) KeyRange(f func(key Coord) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -103,7 +109,7 @@ func (m *CoordMap) KeyRange(f func(key Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordMap) ValueRange(f func(value any) bool) {
+func (m *CoordMap[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -125,7 +131,7 @@ func (m *CoordMap) ValueRange(f func(value any) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordMap) Range(f func(key Coord, value any) bool) {
+func (m *CoordMap[T]) Range(f func(key Coord, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -141,41 +147,46 @@ func (m *CoordMap) Range(f func(key Coord, value any) bool) {
 	}
 }
 
-func (m *CoordMap) fastToSlow() {
-	m.slowMap = map[Coord]any{}
+func (m *CoordMap[T]) fastToSlow() {
+	m.slowMap = map[Coord]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordMap struct {
+type cellForCoordMap[T any] struct {
 	Key   Coord
-	Value any
+	Value T
 }
 
 func hashForCoordMap(c Coord) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToFaces implements a map-like interface for
-// mapping Coord to []*Segment.
+func zeroForCoordMap[T any]() T {
+	var e T
+	return e
+}
+
+// CoordToSlice implements a map-like interface for
+// mapping Coord to []T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToFaces struct {
-	slowMap map[Coord][]*Segment
-	fastMap map[uint64]cellForCoordToFaces
+type CoordToSlice[T any] struct {
+	slowMap map[Coord][]T
+	fastMap map[uint64]cellForCoordToSlice[T]
 }
 
-// NewCoordToFaces creates an empty map.
-func NewCoordToFaces() *CoordToFaces {
-	return &CoordToFaces{fastMap: map[uint64]cellForCoordToFaces{}}
+// NewCoordToSlice creates an empty map.
+func NewCoordToSlice[T any]() *CoordToSlice[T] {
+	return &CoordToSlice[T]{fastMap: map[uint64]cellForCoordToSlice[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordToFaces) Len() int {
+func (m *CoordToSlice[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -185,7 +196,7 @@ func (m *CoordToFaces) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordToFaces) Value(key Coord) []*Segment {
+func (m *CoordToSlice[T]) Value(key Coord) []T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -195,11 +206,11 @@ func (m *CoordToFaces) Value(key Coord) []*Segment {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordToFaces) Load(key Coord) ([]*Segment, bool) {
+func (m *CoordToSlice[T]) Load(key Coord) ([]T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToFaces(key)]
+		cell, ok := m.fastMap[hashForCoordToSlice(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForCoordToSlice[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -210,9 +221,9 @@ func (m *CoordToFaces) Load(key Coord) ([]*Segment, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordToFaces) Delete(key Coord) {
+func (m *CoordToSlice[T]) Delete(key Coord) {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -223,16 +234,16 @@ func (m *CoordToFaces) Delete(key Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordToFaces) Store(key Coord, value []*Segment) {
+func (m *CoordToSlice[T]) Store(key Coord, value []T) {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToSlice[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -241,9 +252,9 @@ func (m *CoordToFaces) Store(key Coord, value []*Segment) {
 
 // Append appends x to the value stored for the given key
 // and returns the new value.
-func (m *CoordToFaces) Append(key Coord, x *Segment) []*Segment {
+func (m *CoordToSlice[T]) Append(key Coord, x T) []T {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
@@ -251,7 +262,7 @@ func (m *CoordToFaces) Append(key Coord, x *Segment) []*Segment {
 			return m.Append(key, x)
 		} else {
 			value := append(cell.Value, x)
-			m.fastMap[hash] = cellForCoordToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToSlice[T]{Key: key, Value: value}
 			return value
 		}
 	} else {
@@ -263,7 +274,7 @@ func (m *CoordToFaces) Append(key Coord, x *Segment) []*Segment {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordToFaces) KeyRange(f func(key Coord) bool) {
+func (m *CoordToSlice[T]) KeyRange(f func(key Coord) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -281,7 +292,7 @@ func (m *CoordToFaces) KeyRange(f func(key Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordToFaces) ValueRange(f func(value []*Segment) bool) {
+func (m *CoordToSlice[T]) ValueRange(f func(value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -303,7 +314,7 @@ func (m *CoordToFaces) ValueRange(f func(value []*Segment) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordToFaces) Range(f func(key Coord, value []*Segment) bool) {
+func (m *CoordToSlice[T]) Range(f func(key Coord, value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -319,41 +330,46 @@ func (m *CoordToFaces) Range(f func(key Coord, value []*Segment) bool) {
 	}
 }
 
-func (m *CoordToFaces) fastToSlow() {
-	m.slowMap = map[Coord][]*Segment{}
+func (m *CoordToSlice[T]) fastToSlow() {
+	m.slowMap = map[Coord][]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordToFaces struct {
+type cellForCoordToSlice[T any] struct {
 	Key   Coord
-	Value []*Segment
+	Value []T
 }
 
-func hashForCoordToFaces(c Coord) uint64 {
+func hashForCoordToSlice(c Coord) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToCoord implements a map-like interface for
-// mapping Coord to Coord.
+func zeroForCoordToSlice[T any]() []T {
+	var e []T
+	return e
+}
+
+// CoordToNumber implements a map-like interface for
+// mapping Coord to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToCoord struct {
-	slowMap map[Coord]Coord
-	fastMap map[uint64]cellForCoordToCoord
+type CoordToNumber[T Adder] struct {
+	slowMap map[Coord]T
+	fastMap map[uint64]cellForCoordToNumber[T]
 }
 
-// NewCoordToCoord creates an empty map.
-func NewCoordToCoord() *CoordToCoord {
-	return &CoordToCoord{fastMap: map[uint64]cellForCoordToCoord{}}
+// NewCoordToNumber creates an empty map.
+func NewCoordToNumber[T Adder]() *CoordToNumber[T] {
+	return &CoordToNumber[T]{fastMap: map[uint64]cellForCoordToNumber[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordToCoord) Len() int {
+func (m *CoordToNumber[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -363,7 +379,7 @@ func (m *CoordToCoord) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordToCoord) Value(key Coord) Coord {
+func (m *CoordToNumber[T]) Value(key Coord) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -373,11 +389,11 @@ func (m *CoordToCoord) Value(key Coord) Coord {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordToCoord) Load(key Coord) (Coord, bool) {
+func (m *CoordToNumber[T]) Load(key Coord) (T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToCoord(key)]
+		cell, ok := m.fastMap[hashForCoordToNumber(key)]
 		if !ok || cell.Key != key {
-			return Coord{}, false
+			return zeroForCoordToNumber[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -388,9 +404,9 @@ func (m *CoordToCoord) Load(key Coord) (Coord, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordToCoord) Delete(key Coord) {
+func (m *CoordToNumber[T]) Delete(key Coord) {
 	if m.fastMap != nil {
-		hash := hashForCoordToCoord(key)
+		hash := hashForCoordToNumber(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -401,172 +417,16 @@ func (m *CoordToCoord) Delete(key Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordToCoord) Store(key Coord, value Coord) {
+func (m *CoordToNumber[T]) Store(key Coord, value T) {
 	if m.fastMap != nil {
-		hash := hashForCoordToCoord(key)
+		hash := hashForCoordToNumber(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordToCoord{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *CoordToCoord) KeyRange(f func(key Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *CoordToCoord) ValueRange(f func(value Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *CoordToCoord) Range(f func(key Coord, value Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *CoordToCoord) fastToSlow() {
-	m.slowMap = map[Coord]Coord{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForCoordToCoord struct {
-	Key   Coord
-	Value Coord
-}
-
-func hashForCoordToCoord(c Coord) uint64 {
-	return c.fastHash64()
-}
-
-// CoordToInt implements a map-like interface for
-// mapping Coord to int.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToInt struct {
-	slowMap map[Coord]int
-	fastMap map[uint64]cellForCoordToInt
-}
-
-// NewCoordToInt creates an empty map.
-func NewCoordToInt() *CoordToInt {
-	return &CoordToInt{fastMap: map[uint64]cellForCoordToInt{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *CoordToInt) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *CoordToInt) Value(key Coord) int {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *CoordToInt) Load(key Coord) (int, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToInt(key)]
-		if !ok || cell.Key != key {
-			return 0, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *CoordToInt) Delete(key Coord) {
-	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *CoordToInt) Store(key Coord, value int) {
-	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForCoordToInt{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToNumber[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -575,16 +435,16 @@ func (m *CoordToInt) Store(key Coord, value int) {
 
 // Add adds x to the value stored for the given key and
 // returns the new value.
-func (m *CoordToInt) Add(key Coord, x int) int {
+func (m *CoordToNumber[T]) Add(key Coord, x T) T {
 	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
+		hash := hashForCoordToNumber(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			return m.Add(key, x)
 		} else {
-			m.fastMap[hash] = cellForCoordToInt{Key: key, Value: cell.Value + x}
+			m.fastMap[hash] = cellForCoordToNumber[T]{Key: key, Value: cell.Value + x}
 			return cell.Value + x
 		}
 	} else {
@@ -596,7 +456,7 @@ func (m *CoordToInt) Add(key Coord, x int) int {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordToInt) KeyRange(f func(key Coord) bool) {
+func (m *CoordToNumber[T]) KeyRange(f func(key Coord) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -614,7 +474,7 @@ func (m *CoordToInt) KeyRange(f func(key Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordToInt) ValueRange(f func(value int) bool) {
+func (m *CoordToNumber[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -636,7 +496,7 @@ func (m *CoordToInt) ValueRange(f func(value int) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordToInt) Range(f func(key Coord, value int) bool) {
+func (m *CoordToNumber[T]) Range(f func(key Coord, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -652,197 +512,46 @@ func (m *CoordToInt) Range(f func(key Coord, value int) bool) {
 	}
 }
 
-func (m *CoordToInt) fastToSlow() {
-	m.slowMap = map[Coord]int{}
+func (m *CoordToNumber[T]) fastToSlow() {
+	m.slowMap = map[Coord]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordToInt struct {
+type cellForCoordToNumber[T Adder] struct {
 	Key   Coord
-	Value int
+	Value T
 }
 
-func hashForCoordToInt(c Coord) uint64 {
+func hashForCoordToNumber(c Coord) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToBool implements a map-like interface for
-// mapping Coord to bool.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToBool struct {
-	slowMap map[Coord]bool
-	fastMap map[uint64]cellForCoordToBool
-}
-
-// NewCoordToBool creates an empty map.
-func NewCoordToBool() *CoordToBool {
-	return &CoordToBool{fastMap: map[uint64]cellForCoordToBool{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *CoordToBool) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *CoordToBool) Value(key Coord) bool {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *CoordToBool) Load(key Coord) (bool, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToBool(key)]
-		if !ok || cell.Key != key {
-			return false, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *CoordToBool) Delete(key Coord) {
-	if m.fastMap != nil {
-		hash := hashForCoordToBool(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *CoordToBool) Store(key Coord, value bool) {
-	if m.fastMap != nil {
-		hash := hashForCoordToBool(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForCoordToBool{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *CoordToBool) KeyRange(f func(key Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *CoordToBool) ValueRange(f func(value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *CoordToBool) Range(f func(key Coord, value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *CoordToBool) fastToSlow() {
-	m.slowMap = map[Coord]bool{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForCoordToBool struct {
-	Key   Coord
-	Value bool
-}
-
-func hashForCoordToBool(c Coord) uint64 {
-	return c.fastHash64()
+func zeroForCoordToNumber[T any]() T {
+	var e T
+	return e
 }
 
 // EdgeMap implements a map-like interface for
-// mapping [2]Coord to any.
+// mapping [2]Coord to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeMap struct {
-	slowMap map[[2]Coord]any
-	fastMap map[uint64]cellForEdgeMap
+type EdgeMap[T any] struct {
+	slowMap map[[2]Coord]T
+	fastMap map[uint64]cellForEdgeMap[T]
 }
 
 // NewEdgeMap creates an empty map.
-func NewEdgeMap() *EdgeMap {
-	return &EdgeMap{fastMap: map[uint64]cellForEdgeMap{}}
+func NewEdgeMap[T any]() *EdgeMap[T] {
+	return &EdgeMap[T]{fastMap: map[uint64]cellForEdgeMap[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *EdgeMap) Len() int {
+func (m *EdgeMap[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -852,7 +561,7 @@ func (m *EdgeMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeMap) Value(key [2]Coord) any {
+func (m *EdgeMap[T]) Value(key [2]Coord) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -862,11 +571,11 @@ func (m *EdgeMap) Value(key [2]Coord) any {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeMap) Load(key [2]Coord) (any, bool) {
+func (m *EdgeMap[T]) Load(key [2]Coord) (T, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForEdgeMap(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForEdgeMap[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -877,7 +586,7 @@ func (m *EdgeMap) Load(key [2]Coord) (any, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *EdgeMap) Delete(key [2]Coord) {
+func (m *EdgeMap[T]) Delete(key [2]Coord) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
@@ -890,7 +599,7 @@ func (m *EdgeMap) Delete(key [2]Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeMap) Store(key [2]Coord, value any) {
+func (m *EdgeMap[T]) Store(key [2]Coord, value T) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		cell, ok := m.fastMap[hash]
@@ -899,7 +608,7 @@ func (m *EdgeMap) Store(key [2]Coord, value any) {
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForEdgeMap{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeMap[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -908,7 +617,7 @@ func (m *EdgeMap) Store(key [2]Coord, value any) {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *EdgeMap) KeyRange(f func(key [2]Coord) bool) {
+func (m *EdgeMap[T]) KeyRange(f func(key [2]Coord) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -926,7 +635,7 @@ func (m *EdgeMap) KeyRange(f func(key [2]Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeMap) ValueRange(f func(value any) bool) {
+func (m *EdgeMap[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -948,7 +657,7 @@ func (m *EdgeMap) ValueRange(f func(value any) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeMap) Range(f func(key [2]Coord, value any) bool) {
+func (m *EdgeMap[T]) Range(f func(key [2]Coord, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -964,17 +673,17 @@ func (m *EdgeMap) Range(f func(key [2]Coord, value any) bool) {
 	}
 }
 
-func (m *EdgeMap) fastToSlow() {
-	m.slowMap = map[[2]Coord]any{}
+func (m *EdgeMap[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForEdgeMap struct {
+type cellForEdgeMap[T any] struct {
 	Key   [2]Coord
-	Value any
+	Value T
 }
 
 func hashForEdgeMap(c [2]Coord) uint64 {
@@ -983,24 +692,29 @@ func hashForEdgeMap(c [2]Coord) uint64 {
 	return uint64(h1) | (uint64(h2) << 32)
 }
 
-// EdgeToBool implements a map-like interface for
-// mapping [2]Coord to bool.
+func zeroForEdgeMap[T any]() T {
+	var e T
+	return e
+}
+
+// EdgeToSlice implements a map-like interface for
+// mapping [2]Coord to []T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToBool struct {
-	slowMap map[[2]Coord]bool
-	fastMap map[uint64]cellForEdgeToBool
+type EdgeToSlice[T any] struct {
+	slowMap map[[2]Coord][]T
+	fastMap map[uint64]cellForEdgeToSlice[T]
 }
 
-// NewEdgeToBool creates an empty map.
-func NewEdgeToBool() *EdgeToBool {
-	return &EdgeToBool{fastMap: map[uint64]cellForEdgeToBool{}}
+// NewEdgeToSlice creates an empty map.
+func NewEdgeToSlice[T any]() *EdgeToSlice[T] {
+	return &EdgeToSlice[T]{fastMap: map[uint64]cellForEdgeToSlice[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *EdgeToBool) Len() int {
+func (m *EdgeToSlice[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -1010,7 +724,7 @@ func (m *EdgeToBool) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeToBool) Value(key [2]Coord) bool {
+func (m *EdgeToSlice[T]) Value(key [2]Coord) []T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -1020,11 +734,11 @@ func (m *EdgeToBool) Value(key [2]Coord) bool {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeToBool) Load(key [2]Coord) (bool, bool) {
+func (m *EdgeToSlice[T]) Load(key [2]Coord) ([]T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToBool(key)]
+		cell, ok := m.fastMap[hashForEdgeToSlice(key)]
 		if !ok || cell.Key != key {
-			return false, false
+			return zeroForEdgeToSlice[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -1035,9 +749,9 @@ func (m *EdgeToBool) Load(key [2]Coord) (bool, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *EdgeToBool) Delete(key [2]Coord) {
+func (m *EdgeToSlice[T]) Delete(key [2]Coord) {
 	if m.fastMap != nil {
-		hash := hashForEdgeToBool(key)
+		hash := hashForEdgeToSlice(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -1048,353 +762,16 @@ func (m *EdgeToBool) Delete(key [2]Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeToBool) Store(key [2]Coord, value bool) {
+func (m *EdgeToSlice[T]) Store(key [2]Coord, value []T) {
 	if m.fastMap != nil {
-		hash := hashForEdgeToBool(key)
+		hash := hashForEdgeToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForEdgeToBool{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *EdgeToBool) KeyRange(f func(key [2]Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *EdgeToBool) ValueRange(f func(value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *EdgeToBool) Range(f func(key [2]Coord, value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *EdgeToBool) fastToSlow() {
-	m.slowMap = map[[2]Coord]bool{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForEdgeToBool struct {
-	Key   [2]Coord
-	Value bool
-}
-
-func hashForEdgeToBool(c [2]Coord) uint64 {
-	h1 := c[0].fastHash()
-	h2 := c[1].fastHash()
-	return uint64(h1) | (uint64(h2) << 32)
-}
-
-// EdgeToInt implements a map-like interface for
-// mapping [2]Coord to int.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToInt struct {
-	slowMap map[[2]Coord]int
-	fastMap map[uint64]cellForEdgeToInt
-}
-
-// NewEdgeToInt creates an empty map.
-func NewEdgeToInt() *EdgeToInt {
-	return &EdgeToInt{fastMap: map[uint64]cellForEdgeToInt{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *EdgeToInt) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *EdgeToInt) Value(key [2]Coord) int {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *EdgeToInt) Load(key [2]Coord) (int, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToInt(key)]
-		if !ok || cell.Key != key {
-			return 0, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *EdgeToInt) Delete(key [2]Coord) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *EdgeToInt) Store(key [2]Coord, value int) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForEdgeToInt{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// Add adds x to the value stored for the given key and
-// returns the new value.
-func (m *EdgeToInt) Add(key [2]Coord, x int) int {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			return m.Add(key, x)
-		} else {
-			m.fastMap[hash] = cellForEdgeToInt{Key: key, Value: cell.Value + x}
-			return cell.Value + x
-		}
-	} else {
-		value := m.slowMap[key] + x
-		m.slowMap[key] = value
-		return value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *EdgeToInt) KeyRange(f func(key [2]Coord) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *EdgeToInt) ValueRange(f func(value int) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *EdgeToInt) Range(f func(key [2]Coord, value int) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *EdgeToInt) fastToSlow() {
-	m.slowMap = map[[2]Coord]int{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForEdgeToInt struct {
-	Key   [2]Coord
-	Value int
-}
-
-func hashForEdgeToInt(c [2]Coord) uint64 {
-	h1 := c[0].fastHash()
-	h2 := c[1].fastHash()
-	return uint64(h1) | (uint64(h2) << 32)
-}
-
-// EdgeToFaces implements a map-like interface for
-// mapping [2]Coord to []*Segment.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToFaces struct {
-	slowMap map[[2]Coord][]*Segment
-	fastMap map[uint64]cellForEdgeToFaces
-}
-
-// NewEdgeToFaces creates an empty map.
-func NewEdgeToFaces() *EdgeToFaces {
-	return &EdgeToFaces{fastMap: map[uint64]cellForEdgeToFaces{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *EdgeToFaces) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *EdgeToFaces) Value(key [2]Coord) []*Segment {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *EdgeToFaces) Load(key [2]Coord) ([]*Segment, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToFaces(key)]
-		if !ok || cell.Key != key {
-			return nil, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *EdgeToFaces) Delete(key [2]Coord) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *EdgeToFaces) Store(key [2]Coord, value []*Segment) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForEdgeToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeToSlice[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -1403,9 +780,9 @@ func (m *EdgeToFaces) Store(key [2]Coord, value []*Segment) {
 
 // Append appends x to the value stored for the given key
 // and returns the new value.
-func (m *EdgeToFaces) Append(key [2]Coord, x *Segment) []*Segment {
+func (m *EdgeToSlice[T]) Append(key [2]Coord, x T) []T {
 	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
+		hash := hashForEdgeToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
@@ -1413,7 +790,7 @@ func (m *EdgeToFaces) Append(key [2]Coord, x *Segment) []*Segment {
 			return m.Append(key, x)
 		} else {
 			value := append(cell.Value, x)
-			m.fastMap[hash] = cellForEdgeToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeToSlice[T]{Key: key, Value: value}
 			return value
 		}
 	} else {
@@ -1425,7 +802,7 @@ func (m *EdgeToFaces) Append(key [2]Coord, x *Segment) []*Segment {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *EdgeToFaces) KeyRange(f func(key [2]Coord) bool) {
+func (m *EdgeToSlice[T]) KeyRange(f func(key [2]Coord) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -1443,7 +820,7 @@ func (m *EdgeToFaces) KeyRange(f func(key [2]Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeToFaces) ValueRange(f func(value []*Segment) bool) {
+func (m *EdgeToSlice[T]) ValueRange(f func(value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -1465,7 +842,7 @@ func (m *EdgeToFaces) ValueRange(f func(value []*Segment) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeToFaces) Range(f func(key [2]Coord, value []*Segment) bool) {
+func (m *EdgeToSlice[T]) Range(f func(key [2]Coord, value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -1481,21 +858,210 @@ func (m *EdgeToFaces) Range(f func(key [2]Coord, value []*Segment) bool) {
 	}
 }
 
-func (m *EdgeToFaces) fastToSlow() {
-	m.slowMap = map[[2]Coord][]*Segment{}
+func (m *EdgeToSlice[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord][]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForEdgeToFaces struct {
+type cellForEdgeToSlice[T any] struct {
 	Key   [2]Coord
-	Value []*Segment
+	Value []T
 }
 
-func hashForEdgeToFaces(c [2]Coord) uint64 {
+func hashForEdgeToSlice(c [2]Coord) uint64 {
 	h1 := c[0].fastHash()
 	h2 := c[1].fastHash()
 	return uint64(h1) | (uint64(h2) << 32)
+}
+
+func zeroForEdgeToSlice[T any]() []T {
+	var e []T
+	return e
+}
+
+// EdgeToNumber implements a map-like interface for
+// mapping [2]Coord to T.
+//
+// This can be more efficient than using a map directly,
+// since it uses a special hash function for coordinates.
+// The speed-up is variable, but was ~2x as of mid-2021.
+type EdgeToNumber[T Adder] struct {
+	slowMap map[[2]Coord]T
+	fastMap map[uint64]cellForEdgeToNumber[T]
+}
+
+// NewEdgeToNumber creates an empty map.
+func NewEdgeToNumber[T Adder]() *EdgeToNumber[T] {
+	return &EdgeToNumber[T]{fastMap: map[uint64]cellForEdgeToNumber[T]{}}
+}
+
+// Len gets the number of elements in the map.
+func (m *EdgeToNumber[T]) Len() int {
+	if m.fastMap != nil {
+		return len(m.fastMap)
+	} else {
+		return len(m.slowMap)
+	}
+}
+
+// Value is like Load(), but without a second return
+// value.
+func (m *EdgeToNumber[T]) Value(key [2]Coord) T {
+	res, _ := m.Load(key)
+	return res
+}
+
+// Load gets the value for the given key.
+//
+// If no value is present, the first return argument is a
+// zero value, and the second is false. Otherwise, the
+// second return value is true.
+func (m *EdgeToNumber[T]) Load(key [2]Coord) (T, bool) {
+	if m.fastMap != nil {
+		cell, ok := m.fastMap[hashForEdgeToNumber(key)]
+		if !ok || cell.Key != key {
+			return zeroForEdgeToNumber[T](), false
+		}
+		return cell.Value, true
+	} else {
+		x, y := m.slowMap[key]
+		return x, y
+	}
+}
+
+// Delete removes the key from the map if it exists, and
+// does nothing otherwise.
+func (m *EdgeToNumber[T]) Delete(key [2]Coord) {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
+			delete(m.fastMap, hash)
+		}
+	} else {
+		delete(m.slowMap, key)
+	}
+}
+
+// Store assigns the value to the given key, overwriting
+// the previous value for the key if necessary.
+func (m *EdgeToNumber[T]) Store(key [2]Coord, value T) {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		cell, ok := m.fastMap[hash]
+		if ok && cell.Key != key {
+			// We must switch to a slow map to store colliding values.
+			m.fastToSlow()
+			m.slowMap[key] = value
+		} else {
+			m.fastMap[hash] = cellForEdgeToNumber[T]{Key: key, Value: value}
+		}
+	} else {
+		m.slowMap[key] = value
+	}
+}
+
+// Add adds x to the value stored for the given key and
+// returns the new value.
+func (m *EdgeToNumber[T]) Add(key [2]Coord, x T) T {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		cell, ok := m.fastMap[hash]
+		if ok && cell.Key != key {
+			// We must switch to a slow map to store colliding values.
+			m.fastToSlow()
+			return m.Add(key, x)
+		} else {
+			m.fastMap[hash] = cellForEdgeToNumber[T]{Key: key, Value: cell.Value + x}
+			return cell.Value + x
+		}
+	} else {
+		value := m.slowMap[key] + x
+		m.slowMap[key] = value
+		return value
+	}
+}
+
+// KeyRange is like Range, but only iterates over
+// keys, not values.
+func (m *EdgeToNumber[T]) KeyRange(f func(key [2]Coord) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Key) {
+				return
+			}
+		}
+	} else {
+		for k := range m.slowMap {
+			if !f(k) {
+				return
+			}
+		}
+	}
+}
+
+// ValueRange is like Range, but only iterates over
+// values only.
+func (m *EdgeToNumber[T]) ValueRange(f func(value T) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Value) {
+				return
+			}
+		}
+	} else {
+		for _, v := range m.slowMap {
+			if !f(v) {
+				return
+			}
+		}
+	}
+}
+
+// Range iterates over the map, calling f successively for
+// each value until it returns false, or all entries are
+// enumerated.
+//
+// It is not safe to modify the map with Store or Delete
+// during enumeration.
+func (m *EdgeToNumber[T]) Range(f func(key [2]Coord, value T) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Key, cell.Value) {
+				return
+			}
+		}
+	} else {
+		for k, v := range m.slowMap {
+			if !f(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (m *EdgeToNumber[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord]T{}
+	for _, cell := range m.fastMap {
+		m.slowMap[cell.Key] = cell.Value
+	}
+	m.fastMap = nil
+}
+
+type cellForEdgeToNumber[T Adder] struct {
+	Key   [2]Coord
+	Value T
+}
+
+func hashForEdgeToNumber(c [2]Coord) uint64 {
+	h1 := c[0].fastHash()
+	h2 := c[1].fastHash()
+	return uint64(h1) | (uint64(h2) << 32)
+}
+
+func zeroForEdgeToNumber[T any]() T {
+	var e T
+	return e
 }

--- a/model2d/fast_maps.go
+++ b/model2d/fast_maps.go
@@ -3,13 +3,13 @@
 package model2d
 
 // CoordMap implements a map-like interface for
-// mapping Coord to interface{}.
+// mapping Coord to any.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
 type CoordMap struct {
-	slowMap map[Coord]interface{}
+	slowMap map[Coord]any
 	fastMap map[uint64]cellForCoordMap
 }
 
@@ -29,7 +29,7 @@ func (m *CoordMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordMap) Value(key Coord) interface{} {
+func (m *CoordMap) Value(key Coord) any {
 	res, _ := m.Load(key)
 	return res
 }
@@ -39,7 +39,7 @@ func (m *CoordMap) Value(key Coord) interface{} {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordMap) Load(key Coord) (interface{}, bool) {
+func (m *CoordMap) Load(key Coord) (any, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForCoordMap(key)]
 		if !ok || cell.Key != key {
@@ -67,7 +67,7 @@ func (m *CoordMap) Delete(key Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordMap) Store(key Coord, value interface{}) {
+func (m *CoordMap) Store(key Coord, value any) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		cell, ok := m.fastMap[hash]
@@ -103,7 +103,7 @@ func (m *CoordMap) KeyRange(f func(key Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordMap) ValueRange(f func(value interface{}) bool) {
+func (m *CoordMap) ValueRange(f func(value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -125,7 +125,7 @@ func (m *CoordMap) ValueRange(f func(value interface{}) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordMap) Range(f func(key Coord, value interface{}) bool) {
+func (m *CoordMap) Range(f func(key Coord, value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -142,7 +142,7 @@ func (m *CoordMap) Range(f func(key Coord, value interface{}) bool) {
 }
 
 func (m *CoordMap) fastToSlow() {
-	m.slowMap = map[Coord]interface{}{}
+	m.slowMap = map[Coord]any{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
@@ -151,7 +151,7 @@ func (m *CoordMap) fastToSlow() {
 
 type cellForCoordMap struct {
 	Key   Coord
-	Value interface{}
+	Value any
 }
 
 func hashForCoordMap(c Coord) uint64 {
@@ -826,13 +826,13 @@ func hashForCoordToBool(c Coord) uint64 {
 }
 
 // EdgeMap implements a map-like interface for
-// mapping [2]Coord to interface{}.
+// mapping [2]Coord to any.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
 type EdgeMap struct {
-	slowMap map[[2]Coord]interface{}
+	slowMap map[[2]Coord]any
 	fastMap map[uint64]cellForEdgeMap
 }
 
@@ -852,7 +852,7 @@ func (m *EdgeMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeMap) Value(key [2]Coord) interface{} {
+func (m *EdgeMap) Value(key [2]Coord) any {
 	res, _ := m.Load(key)
 	return res
 }
@@ -862,7 +862,7 @@ func (m *EdgeMap) Value(key [2]Coord) interface{} {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeMap) Load(key [2]Coord) (interface{}, bool) {
+func (m *EdgeMap) Load(key [2]Coord) (any, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForEdgeMap(key)]
 		if !ok || cell.Key != key {
@@ -890,7 +890,7 @@ func (m *EdgeMap) Delete(key [2]Coord) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeMap) Store(key [2]Coord, value interface{}) {
+func (m *EdgeMap) Store(key [2]Coord, value any) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		cell, ok := m.fastMap[hash]
@@ -926,7 +926,7 @@ func (m *EdgeMap) KeyRange(f func(key [2]Coord) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeMap) ValueRange(f func(value interface{}) bool) {
+func (m *EdgeMap) ValueRange(f func(value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -948,7 +948,7 @@ func (m *EdgeMap) ValueRange(f func(value interface{}) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeMap) Range(f func(key [2]Coord, value interface{}) bool) {
+func (m *EdgeMap) Range(f func(key [2]Coord, value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -965,7 +965,7 @@ func (m *EdgeMap) Range(f func(key [2]Coord, value interface{}) bool) {
 }
 
 func (m *EdgeMap) fastToSlow() {
-	m.slowMap = map[[2]Coord]interface{}{}
+	m.slowMap = map[[2]Coord]any{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
@@ -974,7 +974,7 @@ func (m *EdgeMap) fastToSlow() {
 
 type cellForEdgeMap struct {
 	Key   [2]Coord
-	Value interface{}
+	Value any
 }
 
 func hashForEdgeMap(c [2]Coord) uint64 {

--- a/model2d/fast_maps_test.go
+++ b/model2d/fast_maps_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCoordMap(t *testing.T) {
-	cm := NewCoordMap()
+	cm := NewCoordMap[any]()
 
 	checkBehavior := func() {
 		baseline := map[Coord]int{}
@@ -94,7 +94,7 @@ func TestCoordMap(t *testing.T) {
 
 func BenchmarkCoordMap(b *testing.B) {
 	b.Run("Fast", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c := NewCoordRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -103,7 +103,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Slow", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c1, c2 := findHashCollision()
 		cm.Store(c1, 1337)
 		cm.Store(c2, 1337)
@@ -117,7 +117,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Baseline", func(b *testing.B) {
-		cm := map[Coord]any{}
+		cm := map[Coord]int{}
 		c := NewCoordRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/model2d/fast_maps_test.go
+++ b/model2d/fast_maps_test.go
@@ -42,7 +42,7 @@ func TestCoordMap(t *testing.T) {
 				t.Fatalf("should have length %d but got %d", len(baseline), cm.Len())
 			}
 			count := 0
-			cm.Range(func(k Coord, v interface{}) bool {
+			cm.Range(func(k Coord, v any) bool {
 				count++
 				if baseline[k] != v {
 					t.Fatal("invalid entry")
@@ -117,7 +117,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Baseline", func(b *testing.B) {
-		cm := map[Coord]interface{}{}
+		cm := map[Coord]any{}
 		c := NewCoordRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/model2d/rasterize.go
+++ b/model2d/rasterize.go
@@ -31,7 +31,7 @@ const (
 // This uses the default rasterization settings, such as
 // the default line width and anti-aliasing settings.
 // To change this, use a Rasterizer object directly.
-func Rasterize(path string, obj interface{}, scale float64) error {
+func Rasterize(path string, obj any, scale float64) error {
 	rast := Rasterizer{Scale: scale}
 	img := rast.Rasterize(obj)
 	if err := SaveImage(path, img); err != nil {
@@ -42,7 +42,7 @@ func Rasterize(path string, obj interface{}, scale float64) error {
 
 // RasterizeColor is like Rasterize, but it renders
 // multiple objects in different colors.
-func RasterizeColor(path string, objs []interface{}, colors []color.Color, scale float64) error {
+func RasterizeColor(path string, objs []any, colors []color.Color, scale float64) error {
 	b0 := objs[0].(Bounder)
 	min, max := b0.Min(), b0.Max()
 	for _, obj := range objs {
@@ -172,7 +172,7 @@ type Rasterizer struct {
 }
 
 // Rasterize rasterizes a Solid, Mesh, or Collider.
-func (r *Rasterizer) Rasterize(obj interface{}) *image.Gray {
+func (r *Rasterizer) Rasterize(obj any) *image.Gray {
 	switch obj := obj.(type) {
 	case Solid:
 		return r.RasterizeSolid(obj)

--- a/model2d/util_test.go
+++ b/model2d/util_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Failer interface {
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 }
 
 // ValidateMesh checks if m is manifold and has correct normals.

--- a/model3d/bvh.go
+++ b/model3d/bvh.go
@@ -7,39 +7,42 @@ import (
 	"sort"
 )
 
-// GeneralBVH represents a (possibly unbalanced)
-// axis-aligned bounding box hierarchy.
+// BVH represents a (possibly unbalanced) axis-aligned
+// bounding box hierarchy.
 //
-// A GeneralBVH can store arbitrary Bounders.
-// For a mesh-specific version, see BVH.
-type GeneralBVH struct {
+// A BVH can be used to accelerate collision detection.
+// See BVHToCollider() for more details.
+//
+// A BVH node is either a leaf (a single Bounder), or a
+// branch with two or more children.
+type BVH[B Bounder] struct {
 	// Leaf, if non-nil, is the final bounder.
-	Leaf Bounder
+	Leaf B
 
 	// Branch, if Leaf is nil, points to two children.
-	Branch []*GeneralBVH
+	Branch []*BVH[B]
 }
 
-// NewGeneralBVHAreaDensity creates a GeneralBVH by
-// minimizing the product of each bounding box's area with
+// NewBVHAreaDensity creates a BVH by minimizing
+// the product of each bounding box's area with
 // the number of objects contained in the bounding box at
 // each branch.
 //
 // This is good for efficient ray collision detection.
-func NewGeneralBVHAreaDensity(objects []Bounder) *GeneralBVH {
-	return newGeneralBVH(sortBounders(objects), make([]float64, len(objects)),
-		areaDensityBVHSplit)
+func NewBVHAreaDensity[B Bounder](objects []B) *BVH[B] {
+	return newBVH(sortBounders(objects), make([]float64, len(objects)),
+		areaDensityBVHSplit[B])
 }
 
-func newGeneralBVH(sortedBounders [3][]*flaggedBounder, cache []float64,
-	splitter func([]*flaggedBounder, []float64) (int, float64)) *GeneralBVH {
+func newBVH[B Bounder](sortedBounders [3][]*flaggedBounder[B], cache []float64,
+	splitter func([]*flaggedBounder[B], []float64) (int, float64)) *BVH[B] {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 0 {
 		panic("empty sorted objects")
 	} else if numObjs == 1 {
-		return &GeneralBVH{Leaf: sortedBounders[0][0].B}
+		return &BVH[B]{Leaf: sortedBounders[0][0].B}
 	} else if numObjs == 2 {
-		return &GeneralBVH{Branch: []*GeneralBVH{
+		return &BVH[B]{Branch: []*BVH[B]{
 			{Leaf: sortedBounders[0][0].B},
 			{Leaf: sortedBounders[0][1].B},
 		}}
@@ -49,7 +52,7 @@ func newGeneralBVH(sortedBounders [3][]*flaggedBounder, cache []float64,
 	yIndex, yScore := splitter(sortedBounders[1], cache)
 	zIndex, zScore := splitter(sortedBounders[2], cache)
 
-	var split [2][3][]*flaggedBounder
+	var split [2][3][]*flaggedBounder[B]
 	if xScore < yScore && xScore < zScore {
 		split = splitBounders(sortedBounders, 0, xIndex)
 	} else if yScore < xScore && yScore < zScore {
@@ -57,48 +60,12 @@ func newGeneralBVH(sortedBounders [3][]*flaggedBounder, cache []float64,
 	} else {
 		split = splitBounders(sortedBounders, 2, zIndex)
 	}
-	return &GeneralBVH{
-		Branch: []*GeneralBVH{
-			newGeneralBVH(split[0], cache, splitter),
-			newGeneralBVH(split[1], cache, splitter),
+	return &BVH[B]{
+		Branch: []*BVH[B]{
+			newBVH(split[0], cache, splitter),
+			newBVH(split[1], cache, splitter),
 		},
 	}
-}
-
-// BVH represents a (possibly unbalanced) axis-aligned
-// bounding box hierarchy of triangles.
-//
-// A BVH can be used to accelerate collision detection.
-// See BVHToCollider() for more details.
-//
-// A BVH node is either a leaf (a single triangle), or a branch
-// with two or more children.
-//
-// For a more generic BVH that supports any object rather
-// than just triangles, see GeneralBVH.
-type BVH struct {
-	// Leaf, if non-nil, is the sole object in this node.
-	Leaf *Triangle
-
-	// Branch, if Leaf is nil, points to two children.
-	Branch []*BVH
-}
-
-// NewBVHAreaDensity is like NewGeneralBVHAreaDensity but
-// for triangles.
-func NewBVHAreaDensity(objs []*Triangle) *BVH {
-	return generalBVHToBVH(NewGeneralBVHAreaDensity(facesToBounders(objs)))
-}
-
-func generalBVHToBVH(g *GeneralBVH) *BVH {
-	if g.Leaf != nil {
-		return &BVH{Leaf: g.Leaf.(*Triangle)}
-	}
-	res := &BVH{Branch: make([]*BVH, len(g.Branch))}
-	for i, g1 := range g.Branch {
-		res.Branch[i] = generalBVHToBVH(g1)
-	}
-	return res
 }
 
 // areaDensityBVHSplit chooses a split index that
@@ -109,7 +76,7 @@ func generalBVHToBVH(g *GeneralBVH) *BVH {
 // the number of triangles.
 //
 // The cache must contain at least len(faces) entries.
-func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64) {
+func areaDensityBVHSplit[B Bounder](faces []*flaggedBounder[B], cache []float64) (int, float64) {
 	// Fill the cache with scores going in the other
 	// direction.
 	min, max := faces[len(faces)-1].Min, faces[len(faces)-1].Max
@@ -140,6 +107,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 
 // GroupTriangles is like GroupBounders, but for triangles
 // in particular.
+// This is now equivalent to GroupBounders(faces).
 //
 // This can be used to prepare models for being turned
 // into a collider efficiently, or for storing meshes in
@@ -148,11 +116,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 // The resulting hierarchy can be passed directly to
 // GroupedTrianglesToCollider().
 func GroupTriangles(faces []*Triangle) {
-	bs := facesToBounders(faces)
-	groupBounders(sortBounders(bs), bs)
-	for i, b := range bs {
-		faces[i] = b.(*Triangle)
-	}
+	GroupBounders(faces)
 }
 
 // GroupBounders sorts a slice of objects into a balanced
@@ -164,11 +128,11 @@ func GroupTriangles(faces []*Triangle) {
 // To cut a slice in half, divide the length by two, round
 // down, and use the result as the start index for the
 // second half.
-func GroupBounders(objects []Bounder) {
+func GroupBounders[B Bounder](objects []B) {
 	groupBounders(sortBounders(objects), objects)
 }
 
-func groupBounders(sortedBounders [3][]*flaggedBounder, output []Bounder) {
+func groupBounders[B Bounder](sortedBounders [3][]*flaggedBounder[B], output []B) {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 2 {
 		// The area-based splitting criterion doesn't
@@ -191,12 +155,13 @@ func groupBounders(sortedBounders [3][]*flaggedBounder, output []Bounder) {
 	groupBounders(separated[1], output[midIdx:])
 }
 
-func splitBounders(sortedBounders [3][]*flaggedBounder, axis, midIdx int) [2][3][]*flaggedBounder {
+func splitBounders[B Bounder](sortedBounders [3][]*flaggedBounder[B],
+	axis, midIdx int) [2][3][]*flaggedBounder[B] {
 	for i, b := range sortedBounders[axis] {
 		b.Flag = i < midIdx
 	}
 
-	separated := [3][]*flaggedBounder{}
+	separated := [3][]*flaggedBounder[B]{}
 	separated[axis] = sortedBounders[axis]
 
 	numObjs := len(sortedBounders[0])
@@ -204,7 +169,7 @@ func splitBounders(sortedBounders [3][]*flaggedBounder, axis, midIdx int) [2][3]
 		if newAxis == axis {
 			continue
 		}
-		sep := make([]*flaggedBounder, numObjs)
+		sep := make([]*flaggedBounder[B], numObjs)
 		idx0 := 0
 		idx1 := midIdx
 		for _, b := range sortedBounders[newAxis] {
@@ -219,7 +184,7 @@ func splitBounders(sortedBounders [3][]*flaggedBounder, axis, midIdx int) [2][3]
 		separated[newAxis] = sep
 	}
 
-	return [2][3][]*flaggedBounder{
+	return [2][3][]*flaggedBounder[B]{
 		{
 			separated[0][:midIdx],
 			separated[1][:midIdx], separated[2][:midIdx],
@@ -231,7 +196,7 @@ func splitBounders(sortedBounders [3][]*flaggedBounder, axis, midIdx int) [2][3]
 	}
 }
 
-func bestSplitAxis(sortedBounders [3][]*flaggedBounder) int {
+func bestSplitAxis[B Bounder](sortedBounders [3][]*flaggedBounder[B]) int {
 	midIdx := len(sortedBounders[0]) / 2
 
 	areaForAxis := func(axis int) float64 {
@@ -251,13 +216,13 @@ func bestSplitAxis(sortedBounders [3][]*flaggedBounder) int {
 	return axis
 }
 
-func sortBounders(bs []Bounder) [3][]*flaggedBounder {
+func sortBounders[B Bounder](bs []B) [3][]*flaggedBounder[B] {
 	// Allocate all of the flaggedBounders at once all
 	// next to each other in memory.
-	flagged := make([]flaggedBounder, len(bs))
+	flagged := make([]flaggedBounder[B], len(bs))
 	for i, b := range bs {
 		min, max := b.Min(), b.Max()
-		flagged[i] = flaggedBounder{
+		flagged[i] = flaggedBounder[B]{
 			B:   b,
 			Min: min,
 			Max: max,
@@ -265,9 +230,9 @@ func sortBounders(bs []Bounder) [3][]*flaggedBounder {
 		}
 	}
 
-	var result [3][]*flaggedBounder
+	var result [3][]*flaggedBounder[B]
 	for axis := range result {
-		bsCopy := make([]*flaggedBounder, len(flagged))
+		bsCopy := make([]*flaggedBounder[B], len(flagged))
 		for i := range flagged {
 			bsCopy[i] = &flagged[i]
 		}
@@ -289,7 +254,7 @@ func sortBounders(bs []Bounder) [3][]*flaggedBounder {
 	return result
 }
 
-func multipleBoundsArea(bs []*flaggedBounder) float64 {
+func multipleBoundsArea[B Bounder](bs []*flaggedBounder[B]) float64 {
 	min, max := bs[0].Min, bs[0].Max
 	for i := 1; i < len(bs); i++ {
 		b := bs[i]
@@ -326,8 +291,8 @@ func boundsArea(min, max Coord3D) float64 {
 	return 2 * (diff.X*(diff.Y+diff.Z) + diff.Y*diff.Z)
 }
 
-type flaggedBounder struct {
-	B    Bounder
+type flaggedBounder[B Bounder] struct {
+	B    B
 	Min  Coord3D
 	Max  Coord3D
 	Mid  Coord3D
@@ -383,12 +348,4 @@ func rayCollisionWithBounds(r *Ray, min, max Coord3D) (minFrac, maxFrac float64)
 		}
 	}
 	return
-}
-
-func facesToBounders(faces []*Triangle) []Bounder {
-	bs := make([]Bounder, len(faces))
-	for i, t := range faces {
-		bs[i] = t
-	}
-	return bs
 }

--- a/model3d/collisions.go
+++ b/model3d/collisions.go
@@ -31,7 +31,7 @@ type RayCollision struct {
 	// information about the collision.
 	//
 	// For an example, see TriangleCollision.
-	Extra interface{}
+	Extra any
 }
 
 // TriangleCollision is triangle-specific collision
@@ -200,7 +200,7 @@ func GroupedCollidersToCollider(colliders []Collider) Collider {
 
 // BVHToCollider converts a BVH into a MultiCollider in a
 // hierarchical way.
-func BVHToCollider(b *BVH) MultiCollider {
+func BVHToCollider(b *BVH[*Triangle]) MultiCollider {
 	if b.Leaf != nil {
 		return b.Leaf
 	}

--- a/model3d/export.go
+++ b/model3d/export.go
@@ -82,7 +82,7 @@ func EncodePLY(triangles []*Triangle, colorFunc func(Coord3D) [3]uint8) []byte {
 func WritePLY(w io.Writer, triangles []*Triangle, colorFunc func(Coord3D) [3]uint8) error {
 	coords := [][3]float64{}
 	colors := [][3]uint8{}
-	coordToIdx := NewCoordToInt()
+	coordToIdx := NewCoordMap[int]()
 	for _, t := range triangles {
 		for _, p := range t {
 			if _, ok := coordToIdx.Load(p); !ok {
@@ -236,7 +236,7 @@ func BuildMaterialOBJ(t []*Triangle, c func(t *Triangle) [3]float64) (o *filefor
 	})
 
 	colorToMat := map[[3]float32]int{}
-	coordToIdx := NewCoordToInt()
+	coordToIdx := NewCoordToNumber[int]()
 	for i, tri := range t {
 		color32 := triColors[i]
 		matIdx, ok := colorToMat[color32]

--- a/model3d/fast_maps.go
+++ b/model3d/fast_maps.go
@@ -2,24 +2,30 @@
 
 package model3d
 
+type Adder interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 | ~complex64 | ~complex128
+}
+
 // CoordMap implements a map-like interface for
-// mapping Coord3D to any.
+// mapping Coord3D to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordMap struct {
-	slowMap map[Coord3D]any
-	fastMap map[uint64]cellForCoordMap
+type CoordMap[T any] struct {
+	slowMap map[Coord3D]T
+	fastMap map[uint64]cellForCoordMap[T]
 }
 
 // NewCoordMap creates an empty map.
-func NewCoordMap() *CoordMap {
-	return &CoordMap{fastMap: map[uint64]cellForCoordMap{}}
+func NewCoordMap[T any]() *CoordMap[T] {
+	return &CoordMap[T]{fastMap: map[uint64]cellForCoordMap[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordMap) Len() int {
+func (m *CoordMap[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -29,7 +35,7 @@ func (m *CoordMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordMap) Value(key Coord3D) any {
+func (m *CoordMap[T]) Value(key Coord3D) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -39,11 +45,11 @@ func (m *CoordMap) Value(key Coord3D) any {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordMap) Load(key Coord3D) (any, bool) {
+func (m *CoordMap[T]) Load(key Coord3D) (T, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForCoordMap(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForCoordMap[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -54,7 +60,7 @@ func (m *CoordMap) Load(key Coord3D) (any, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordMap) Delete(key Coord3D) {
+func (m *CoordMap[T]) Delete(key Coord3D) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
@@ -67,7 +73,7 @@ func (m *CoordMap) Delete(key Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordMap) Store(key Coord3D, value any) {
+func (m *CoordMap[T]) Store(key Coord3D, value T) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		cell, ok := m.fastMap[hash]
@@ -76,7 +82,7 @@ func (m *CoordMap) Store(key Coord3D, value any) {
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordMap{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordMap[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -85,7 +91,7 @@ func (m *CoordMap) Store(key Coord3D, value any) {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordMap) KeyRange(f func(key Coord3D) bool) {
+func (m *CoordMap[T]) KeyRange(f func(key Coord3D) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -103,7 +109,7 @@ func (m *CoordMap) KeyRange(f func(key Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordMap) ValueRange(f func(value any) bool) {
+func (m *CoordMap[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -125,7 +131,7 @@ func (m *CoordMap) ValueRange(f func(value any) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordMap) Range(f func(key Coord3D, value any) bool) {
+func (m *CoordMap[T]) Range(f func(key Coord3D, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -141,41 +147,46 @@ func (m *CoordMap) Range(f func(key Coord3D, value any) bool) {
 	}
 }
 
-func (m *CoordMap) fastToSlow() {
-	m.slowMap = map[Coord3D]any{}
+func (m *CoordMap[T]) fastToSlow() {
+	m.slowMap = map[Coord3D]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordMap struct {
+type cellForCoordMap[T any] struct {
 	Key   Coord3D
-	Value any
+	Value T
 }
 
 func hashForCoordMap(c Coord3D) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToFaces implements a map-like interface for
-// mapping Coord3D to []*Triangle.
+func zeroForCoordMap[T any]() T {
+	var e T
+	return e
+}
+
+// CoordToSlice implements a map-like interface for
+// mapping Coord3D to []T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToFaces struct {
-	slowMap map[Coord3D][]*Triangle
-	fastMap map[uint64]cellForCoordToFaces
+type CoordToSlice[T any] struct {
+	slowMap map[Coord3D][]T
+	fastMap map[uint64]cellForCoordToSlice[T]
 }
 
-// NewCoordToFaces creates an empty map.
-func NewCoordToFaces() *CoordToFaces {
-	return &CoordToFaces{fastMap: map[uint64]cellForCoordToFaces{}}
+// NewCoordToSlice creates an empty map.
+func NewCoordToSlice[T any]() *CoordToSlice[T] {
+	return &CoordToSlice[T]{fastMap: map[uint64]cellForCoordToSlice[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordToFaces) Len() int {
+func (m *CoordToSlice[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -185,7 +196,7 @@ func (m *CoordToFaces) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordToFaces) Value(key Coord3D) []*Triangle {
+func (m *CoordToSlice[T]) Value(key Coord3D) []T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -195,11 +206,11 @@ func (m *CoordToFaces) Value(key Coord3D) []*Triangle {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordToFaces) Load(key Coord3D) ([]*Triangle, bool) {
+func (m *CoordToSlice[T]) Load(key Coord3D) ([]T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToFaces(key)]
+		cell, ok := m.fastMap[hashForCoordToSlice(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForCoordToSlice[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -210,9 +221,9 @@ func (m *CoordToFaces) Load(key Coord3D) ([]*Triangle, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordToFaces) Delete(key Coord3D) {
+func (m *CoordToSlice[T]) Delete(key Coord3D) {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -223,16 +234,16 @@ func (m *CoordToFaces) Delete(key Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordToFaces) Store(key Coord3D, value []*Triangle) {
+func (m *CoordToSlice[T]) Store(key Coord3D, value []T) {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToSlice[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -241,9 +252,9 @@ func (m *CoordToFaces) Store(key Coord3D, value []*Triangle) {
 
 // Append appends x to the value stored for the given key
 // and returns the new value.
-func (m *CoordToFaces) Append(key Coord3D, x *Triangle) []*Triangle {
+func (m *CoordToSlice[T]) Append(key Coord3D, x T) []T {
 	if m.fastMap != nil {
-		hash := hashForCoordToFaces(key)
+		hash := hashForCoordToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
@@ -251,7 +262,7 @@ func (m *CoordToFaces) Append(key Coord3D, x *Triangle) []*Triangle {
 			return m.Append(key, x)
 		} else {
 			value := append(cell.Value, x)
-			m.fastMap[hash] = cellForCoordToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToSlice[T]{Key: key, Value: value}
 			return value
 		}
 	} else {
@@ -263,7 +274,7 @@ func (m *CoordToFaces) Append(key Coord3D, x *Triangle) []*Triangle {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordToFaces) KeyRange(f func(key Coord3D) bool) {
+func (m *CoordToSlice[T]) KeyRange(f func(key Coord3D) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -281,7 +292,7 @@ func (m *CoordToFaces) KeyRange(f func(key Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordToFaces) ValueRange(f func(value []*Triangle) bool) {
+func (m *CoordToSlice[T]) ValueRange(f func(value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -303,7 +314,7 @@ func (m *CoordToFaces) ValueRange(f func(value []*Triangle) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordToFaces) Range(f func(key Coord3D, value []*Triangle) bool) {
+func (m *CoordToSlice[T]) Range(f func(key Coord3D, value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -319,41 +330,46 @@ func (m *CoordToFaces) Range(f func(key Coord3D, value []*Triangle) bool) {
 	}
 }
 
-func (m *CoordToFaces) fastToSlow() {
-	m.slowMap = map[Coord3D][]*Triangle{}
+func (m *CoordToSlice[T]) fastToSlow() {
+	m.slowMap = map[Coord3D][]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordToFaces struct {
+type cellForCoordToSlice[T any] struct {
 	Key   Coord3D
-	Value []*Triangle
+	Value []T
 }
 
-func hashForCoordToFaces(c Coord3D) uint64 {
+func hashForCoordToSlice(c Coord3D) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToCoord implements a map-like interface for
-// mapping Coord3D to Coord3D.
+func zeroForCoordToSlice[T any]() []T {
+	var e []T
+	return e
+}
+
+// CoordToNumber implements a map-like interface for
+// mapping Coord3D to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToCoord struct {
-	slowMap map[Coord3D]Coord3D
-	fastMap map[uint64]cellForCoordToCoord
+type CoordToNumber[T Adder] struct {
+	slowMap map[Coord3D]T
+	fastMap map[uint64]cellForCoordToNumber[T]
 }
 
-// NewCoordToCoord creates an empty map.
-func NewCoordToCoord() *CoordToCoord {
-	return &CoordToCoord{fastMap: map[uint64]cellForCoordToCoord{}}
+// NewCoordToNumber creates an empty map.
+func NewCoordToNumber[T Adder]() *CoordToNumber[T] {
+	return &CoordToNumber[T]{fastMap: map[uint64]cellForCoordToNumber[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *CoordToCoord) Len() int {
+func (m *CoordToNumber[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -363,7 +379,7 @@ func (m *CoordToCoord) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordToCoord) Value(key Coord3D) Coord3D {
+func (m *CoordToNumber[T]) Value(key Coord3D) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -373,11 +389,11 @@ func (m *CoordToCoord) Value(key Coord3D) Coord3D {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordToCoord) Load(key Coord3D) (Coord3D, bool) {
+func (m *CoordToNumber[T]) Load(key Coord3D) (T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToCoord(key)]
+		cell, ok := m.fastMap[hashForCoordToNumber(key)]
 		if !ok || cell.Key != key {
-			return Coord3D{}, false
+			return zeroForCoordToNumber[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -388,9 +404,9 @@ func (m *CoordToCoord) Load(key Coord3D) (Coord3D, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *CoordToCoord) Delete(key Coord3D) {
+func (m *CoordToNumber[T]) Delete(key Coord3D) {
 	if m.fastMap != nil {
-		hash := hashForCoordToCoord(key)
+		hash := hashForCoordToNumber(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -401,172 +417,16 @@ func (m *CoordToCoord) Delete(key Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordToCoord) Store(key Coord3D, value Coord3D) {
+func (m *CoordToNumber[T]) Store(key Coord3D, value T) {
 	if m.fastMap != nil {
-		hash := hashForCoordToCoord(key)
+		hash := hashForCoordToNumber(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForCoordToCoord{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *CoordToCoord) KeyRange(f func(key Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *CoordToCoord) ValueRange(f func(value Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *CoordToCoord) Range(f func(key Coord3D, value Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *CoordToCoord) fastToSlow() {
-	m.slowMap = map[Coord3D]Coord3D{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForCoordToCoord struct {
-	Key   Coord3D
-	Value Coord3D
-}
-
-func hashForCoordToCoord(c Coord3D) uint64 {
-	return c.fastHash64()
-}
-
-// CoordToInt implements a map-like interface for
-// mapping Coord3D to int.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToInt struct {
-	slowMap map[Coord3D]int
-	fastMap map[uint64]cellForCoordToInt
-}
-
-// NewCoordToInt creates an empty map.
-func NewCoordToInt() *CoordToInt {
-	return &CoordToInt{fastMap: map[uint64]cellForCoordToInt{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *CoordToInt) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *CoordToInt) Value(key Coord3D) int {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *CoordToInt) Load(key Coord3D) (int, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToInt(key)]
-		if !ok || cell.Key != key {
-			return 0, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *CoordToInt) Delete(key Coord3D) {
-	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *CoordToInt) Store(key Coord3D, value int) {
-	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForCoordToInt{Key: key, Value: value}
+			m.fastMap[hash] = cellForCoordToNumber[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -575,16 +435,16 @@ func (m *CoordToInt) Store(key Coord3D, value int) {
 
 // Add adds x to the value stored for the given key and
 // returns the new value.
-func (m *CoordToInt) Add(key Coord3D, x int) int {
+func (m *CoordToNumber[T]) Add(key Coord3D, x T) T {
 	if m.fastMap != nil {
-		hash := hashForCoordToInt(key)
+		hash := hashForCoordToNumber(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			return m.Add(key, x)
 		} else {
-			m.fastMap[hash] = cellForCoordToInt{Key: key, Value: cell.Value + x}
+			m.fastMap[hash] = cellForCoordToNumber[T]{Key: key, Value: cell.Value + x}
 			return cell.Value + x
 		}
 	} else {
@@ -596,7 +456,7 @@ func (m *CoordToInt) Add(key Coord3D, x int) int {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *CoordToInt) KeyRange(f func(key Coord3D) bool) {
+func (m *CoordToNumber[T]) KeyRange(f func(key Coord3D) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -614,7 +474,7 @@ func (m *CoordToInt) KeyRange(f func(key Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordToInt) ValueRange(f func(value int) bool) {
+func (m *CoordToNumber[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -636,7 +496,7 @@ func (m *CoordToInt) ValueRange(f func(value int) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordToInt) Range(f func(key Coord3D, value int) bool) {
+func (m *CoordToNumber[T]) Range(f func(key Coord3D, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -652,197 +512,46 @@ func (m *CoordToInt) Range(f func(key Coord3D, value int) bool) {
 	}
 }
 
-func (m *CoordToInt) fastToSlow() {
-	m.slowMap = map[Coord3D]int{}
+func (m *CoordToNumber[T]) fastToSlow() {
+	m.slowMap = map[Coord3D]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForCoordToInt struct {
+type cellForCoordToNumber[T Adder] struct {
 	Key   Coord3D
-	Value int
+	Value T
 }
 
-func hashForCoordToInt(c Coord3D) uint64 {
+func hashForCoordToNumber(c Coord3D) uint64 {
 	return c.fastHash64()
 }
 
-// CoordToBool implements a map-like interface for
-// mapping Coord3D to bool.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type CoordToBool struct {
-	slowMap map[Coord3D]bool
-	fastMap map[uint64]cellForCoordToBool
-}
-
-// NewCoordToBool creates an empty map.
-func NewCoordToBool() *CoordToBool {
-	return &CoordToBool{fastMap: map[uint64]cellForCoordToBool{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *CoordToBool) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *CoordToBool) Value(key Coord3D) bool {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *CoordToBool) Load(key Coord3D) (bool, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForCoordToBool(key)]
-		if !ok || cell.Key != key {
-			return false, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *CoordToBool) Delete(key Coord3D) {
-	if m.fastMap != nil {
-		hash := hashForCoordToBool(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *CoordToBool) Store(key Coord3D, value bool) {
-	if m.fastMap != nil {
-		hash := hashForCoordToBool(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForCoordToBool{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *CoordToBool) KeyRange(f func(key Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *CoordToBool) ValueRange(f func(value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *CoordToBool) Range(f func(key Coord3D, value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *CoordToBool) fastToSlow() {
-	m.slowMap = map[Coord3D]bool{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForCoordToBool struct {
-	Key   Coord3D
-	Value bool
-}
-
-func hashForCoordToBool(c Coord3D) uint64 {
-	return c.fastHash64()
+func zeroForCoordToNumber[T any]() T {
+	var e T
+	return e
 }
 
 // EdgeMap implements a map-like interface for
-// mapping [2]Coord3D to any.
+// mapping [2]Coord3D to T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeMap struct {
-	slowMap map[[2]Coord3D]any
-	fastMap map[uint64]cellForEdgeMap
+type EdgeMap[T any] struct {
+	slowMap map[[2]Coord3D]T
+	fastMap map[uint64]cellForEdgeMap[T]
 }
 
 // NewEdgeMap creates an empty map.
-func NewEdgeMap() *EdgeMap {
-	return &EdgeMap{fastMap: map[uint64]cellForEdgeMap{}}
+func NewEdgeMap[T any]() *EdgeMap[T] {
+	return &EdgeMap[T]{fastMap: map[uint64]cellForEdgeMap[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *EdgeMap) Len() int {
+func (m *EdgeMap[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -852,7 +561,7 @@ func (m *EdgeMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeMap) Value(key [2]Coord3D) any {
+func (m *EdgeMap[T]) Value(key [2]Coord3D) T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -862,11 +571,11 @@ func (m *EdgeMap) Value(key [2]Coord3D) any {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeMap) Load(key [2]Coord3D) (any, bool) {
+func (m *EdgeMap[T]) Load(key [2]Coord3D) (T, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForEdgeMap(key)]
 		if !ok || cell.Key != key {
-			return nil, false
+			return zeroForEdgeMap[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -877,7 +586,7 @@ func (m *EdgeMap) Load(key [2]Coord3D) (any, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *EdgeMap) Delete(key [2]Coord3D) {
+func (m *EdgeMap[T]) Delete(key [2]Coord3D) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
@@ -890,7 +599,7 @@ func (m *EdgeMap) Delete(key [2]Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeMap) Store(key [2]Coord3D, value any) {
+func (m *EdgeMap[T]) Store(key [2]Coord3D, value T) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		cell, ok := m.fastMap[hash]
@@ -899,7 +608,7 @@ func (m *EdgeMap) Store(key [2]Coord3D, value any) {
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForEdgeMap{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeMap[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -908,7 +617,7 @@ func (m *EdgeMap) Store(key [2]Coord3D, value any) {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *EdgeMap) KeyRange(f func(key [2]Coord3D) bool) {
+func (m *EdgeMap[T]) KeyRange(f func(key [2]Coord3D) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -926,7 +635,7 @@ func (m *EdgeMap) KeyRange(f func(key [2]Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeMap) ValueRange(f func(value any) bool) {
+func (m *EdgeMap[T]) ValueRange(f func(value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -948,7 +657,7 @@ func (m *EdgeMap) ValueRange(f func(value any) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeMap) Range(f func(key [2]Coord3D, value any) bool) {
+func (m *EdgeMap[T]) Range(f func(key [2]Coord3D, value T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -964,17 +673,17 @@ func (m *EdgeMap) Range(f func(key [2]Coord3D, value any) bool) {
 	}
 }
 
-func (m *EdgeMap) fastToSlow() {
-	m.slowMap = map[[2]Coord3D]any{}
+func (m *EdgeMap[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord3D]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForEdgeMap struct {
+type cellForEdgeMap[T any] struct {
 	Key   [2]Coord3D
-	Value any
+	Value T
 }
 
 func hashForEdgeMap(c [2]Coord3D) uint64 {
@@ -983,24 +692,29 @@ func hashForEdgeMap(c [2]Coord3D) uint64 {
 	return uint64(h1) | (uint64(h2) << 32)
 }
 
-// EdgeToBool implements a map-like interface for
-// mapping [2]Coord3D to bool.
+func zeroForEdgeMap[T any]() T {
+	var e T
+	return e
+}
+
+// EdgeToSlice implements a map-like interface for
+// mapping [2]Coord3D to []T.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToBool struct {
-	slowMap map[[2]Coord3D]bool
-	fastMap map[uint64]cellForEdgeToBool
+type EdgeToSlice[T any] struct {
+	slowMap map[[2]Coord3D][]T
+	fastMap map[uint64]cellForEdgeToSlice[T]
 }
 
-// NewEdgeToBool creates an empty map.
-func NewEdgeToBool() *EdgeToBool {
-	return &EdgeToBool{fastMap: map[uint64]cellForEdgeToBool{}}
+// NewEdgeToSlice creates an empty map.
+func NewEdgeToSlice[T any]() *EdgeToSlice[T] {
+	return &EdgeToSlice[T]{fastMap: map[uint64]cellForEdgeToSlice[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *EdgeToBool) Len() int {
+func (m *EdgeToSlice[T]) Len() int {
 	if m.fastMap != nil {
 		return len(m.fastMap)
 	} else {
@@ -1010,7 +724,7 @@ func (m *EdgeToBool) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeToBool) Value(key [2]Coord3D) bool {
+func (m *EdgeToSlice[T]) Value(key [2]Coord3D) []T {
 	res, _ := m.Load(key)
 	return res
 }
@@ -1020,11 +734,11 @@ func (m *EdgeToBool) Value(key [2]Coord3D) bool {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeToBool) Load(key [2]Coord3D) (bool, bool) {
+func (m *EdgeToSlice[T]) Load(key [2]Coord3D) ([]T, bool) {
 	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToBool(key)]
+		cell, ok := m.fastMap[hashForEdgeToSlice(key)]
 		if !ok || cell.Key != key {
-			return false, false
+			return zeroForEdgeToSlice[T](), false
 		}
 		return cell.Value, true
 	} else {
@@ -1035,9 +749,9 @@ func (m *EdgeToBool) Load(key [2]Coord3D) (bool, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *EdgeToBool) Delete(key [2]Coord3D) {
+func (m *EdgeToSlice[T]) Delete(key [2]Coord3D) {
 	if m.fastMap != nil {
-		hash := hashForEdgeToBool(key)
+		hash := hashForEdgeToSlice(key)
 		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
 			delete(m.fastMap, hash)
 		}
@@ -1048,353 +762,16 @@ func (m *EdgeToBool) Delete(key [2]Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeToBool) Store(key [2]Coord3D, value bool) {
+func (m *EdgeToSlice[T]) Store(key [2]Coord3D, value []T) {
 	if m.fastMap != nil {
-		hash := hashForEdgeToBool(key)
+		hash := hashForEdgeToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
 			m.fastToSlow()
 			m.slowMap[key] = value
 		} else {
-			m.fastMap[hash] = cellForEdgeToBool{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *EdgeToBool) KeyRange(f func(key [2]Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *EdgeToBool) ValueRange(f func(value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *EdgeToBool) Range(f func(key [2]Coord3D, value bool) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *EdgeToBool) fastToSlow() {
-	m.slowMap = map[[2]Coord3D]bool{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForEdgeToBool struct {
-	Key   [2]Coord3D
-	Value bool
-}
-
-func hashForEdgeToBool(c [2]Coord3D) uint64 {
-	h1 := c[0].fastHash()
-	h2 := c[1].fastHash()
-	return uint64(h1) | (uint64(h2) << 32)
-}
-
-// EdgeToInt implements a map-like interface for
-// mapping [2]Coord3D to int.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToInt struct {
-	slowMap map[[2]Coord3D]int
-	fastMap map[uint64]cellForEdgeToInt
-}
-
-// NewEdgeToInt creates an empty map.
-func NewEdgeToInt() *EdgeToInt {
-	return &EdgeToInt{fastMap: map[uint64]cellForEdgeToInt{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *EdgeToInt) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *EdgeToInt) Value(key [2]Coord3D) int {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *EdgeToInt) Load(key [2]Coord3D) (int, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToInt(key)]
-		if !ok || cell.Key != key {
-			return 0, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *EdgeToInt) Delete(key [2]Coord3D) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *EdgeToInt) Store(key [2]Coord3D, value int) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForEdgeToInt{Key: key, Value: value}
-		}
-	} else {
-		m.slowMap[key] = value
-	}
-}
-
-// Add adds x to the value stored for the given key and
-// returns the new value.
-func (m *EdgeToInt) Add(key [2]Coord3D, x int) int {
-	if m.fastMap != nil {
-		hash := hashForEdgeToInt(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			return m.Add(key, x)
-		} else {
-			m.fastMap[hash] = cellForEdgeToInt{Key: key, Value: cell.Value + x}
-			return cell.Value + x
-		}
-	} else {
-		value := m.slowMap[key] + x
-		m.slowMap[key] = value
-		return value
-	}
-}
-
-// KeyRange is like Range, but only iterates over
-// keys, not values.
-func (m *EdgeToInt) KeyRange(f func(key [2]Coord3D) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key) {
-				return
-			}
-		}
-	} else {
-		for k := range m.slowMap {
-			if !f(k) {
-				return
-			}
-		}
-	}
-}
-
-// ValueRange is like Range, but only iterates over
-// values only.
-func (m *EdgeToInt) ValueRange(f func(value int) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Value) {
-				return
-			}
-		}
-	} else {
-		for _, v := range m.slowMap {
-			if !f(v) {
-				return
-			}
-		}
-	}
-}
-
-// Range iterates over the map, calling f successively for
-// each value until it returns false, or all entries are
-// enumerated.
-//
-// It is not safe to modify the map with Store or Delete
-// during enumeration.
-func (m *EdgeToInt) Range(f func(key [2]Coord3D, value int) bool) {
-	if m.fastMap != nil {
-		for _, cell := range m.fastMap {
-			if !f(cell.Key, cell.Value) {
-				return
-			}
-		}
-	} else {
-		for k, v := range m.slowMap {
-			if !f(k, v) {
-				return
-			}
-		}
-	}
-}
-
-func (m *EdgeToInt) fastToSlow() {
-	m.slowMap = map[[2]Coord3D]int{}
-	for _, cell := range m.fastMap {
-		m.slowMap[cell.Key] = cell.Value
-	}
-	m.fastMap = nil
-}
-
-type cellForEdgeToInt struct {
-	Key   [2]Coord3D
-	Value int
-}
-
-func hashForEdgeToInt(c [2]Coord3D) uint64 {
-	h1 := c[0].fastHash()
-	h2 := c[1].fastHash()
-	return uint64(h1) | (uint64(h2) << 32)
-}
-
-// EdgeToFaces implements a map-like interface for
-// mapping [2]Coord3D to []*Triangle.
-//
-// This can be more efficient than using a map directly,
-// since it uses a special hash function for coordinates.
-// The speed-up is variable, but was ~2x as of mid-2021.
-type EdgeToFaces struct {
-	slowMap map[[2]Coord3D][]*Triangle
-	fastMap map[uint64]cellForEdgeToFaces
-}
-
-// NewEdgeToFaces creates an empty map.
-func NewEdgeToFaces() *EdgeToFaces {
-	return &EdgeToFaces{fastMap: map[uint64]cellForEdgeToFaces{}}
-}
-
-// Len gets the number of elements in the map.
-func (m *EdgeToFaces) Len() int {
-	if m.fastMap != nil {
-		return len(m.fastMap)
-	} else {
-		return len(m.slowMap)
-	}
-}
-
-// Value is like Load(), but without a second return
-// value.
-func (m *EdgeToFaces) Value(key [2]Coord3D) []*Triangle {
-	res, _ := m.Load(key)
-	return res
-}
-
-// Load gets the value for the given key.
-//
-// If no value is present, the first return argument is a
-// zero value, and the second is false. Otherwise, the
-// second return value is true.
-func (m *EdgeToFaces) Load(key [2]Coord3D) ([]*Triangle, bool) {
-	if m.fastMap != nil {
-		cell, ok := m.fastMap[hashForEdgeToFaces(key)]
-		if !ok || cell.Key != key {
-			return nil, false
-		}
-		return cell.Value, true
-	} else {
-		x, y := m.slowMap[key]
-		return x, y
-	}
-}
-
-// Delete removes the key from the map if it exists, and
-// does nothing otherwise.
-func (m *EdgeToFaces) Delete(key [2]Coord3D) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
-		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
-			delete(m.fastMap, hash)
-		}
-	} else {
-		delete(m.slowMap, key)
-	}
-}
-
-// Store assigns the value to the given key, overwriting
-// the previous value for the key if necessary.
-func (m *EdgeToFaces) Store(key [2]Coord3D, value []*Triangle) {
-	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
-		cell, ok := m.fastMap[hash]
-		if ok && cell.Key != key {
-			// We must switch to a slow map to store colliding values.
-			m.fastToSlow()
-			m.slowMap[key] = value
-		} else {
-			m.fastMap[hash] = cellForEdgeToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeToSlice[T]{Key: key, Value: value}
 		}
 	} else {
 		m.slowMap[key] = value
@@ -1403,9 +780,9 @@ func (m *EdgeToFaces) Store(key [2]Coord3D, value []*Triangle) {
 
 // Append appends x to the value stored for the given key
 // and returns the new value.
-func (m *EdgeToFaces) Append(key [2]Coord3D, x *Triangle) []*Triangle {
+func (m *EdgeToSlice[T]) Append(key [2]Coord3D, x T) []T {
 	if m.fastMap != nil {
-		hash := hashForEdgeToFaces(key)
+		hash := hashForEdgeToSlice(key)
 		cell, ok := m.fastMap[hash]
 		if ok && cell.Key != key {
 			// We must switch to a slow map to store colliding values.
@@ -1413,7 +790,7 @@ func (m *EdgeToFaces) Append(key [2]Coord3D, x *Triangle) []*Triangle {
 			return m.Append(key, x)
 		} else {
 			value := append(cell.Value, x)
-			m.fastMap[hash] = cellForEdgeToFaces{Key: key, Value: value}
+			m.fastMap[hash] = cellForEdgeToSlice[T]{Key: key, Value: value}
 			return value
 		}
 	} else {
@@ -1425,7 +802,7 @@ func (m *EdgeToFaces) Append(key [2]Coord3D, x *Triangle) []*Triangle {
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *EdgeToFaces) KeyRange(f func(key [2]Coord3D) bool) {
+func (m *EdgeToSlice[T]) KeyRange(f func(key [2]Coord3D) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key) {
@@ -1443,7 +820,7 @@ func (m *EdgeToFaces) KeyRange(f func(key [2]Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeToFaces) ValueRange(f func(value []*Triangle) bool) {
+func (m *EdgeToSlice[T]) ValueRange(f func(value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -1465,7 +842,7 @@ func (m *EdgeToFaces) ValueRange(f func(value []*Triangle) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeToFaces) Range(f func(key [2]Coord3D, value []*Triangle) bool) {
+func (m *EdgeToSlice[T]) Range(f func(key [2]Coord3D, value []T) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -1481,21 +858,210 @@ func (m *EdgeToFaces) Range(f func(key [2]Coord3D, value []*Triangle) bool) {
 	}
 }
 
-func (m *EdgeToFaces) fastToSlow() {
-	m.slowMap = map[[2]Coord3D][]*Triangle{}
+func (m *EdgeToSlice[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord3D][]T{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
 	m.fastMap = nil
 }
 
-type cellForEdgeToFaces struct {
+type cellForEdgeToSlice[T any] struct {
 	Key   [2]Coord3D
-	Value []*Triangle
+	Value []T
 }
 
-func hashForEdgeToFaces(c [2]Coord3D) uint64 {
+func hashForEdgeToSlice(c [2]Coord3D) uint64 {
 	h1 := c[0].fastHash()
 	h2 := c[1].fastHash()
 	return uint64(h1) | (uint64(h2) << 32)
+}
+
+func zeroForEdgeToSlice[T any]() []T {
+	var e []T
+	return e
+}
+
+// EdgeToNumber implements a map-like interface for
+// mapping [2]Coord3D to T.
+//
+// This can be more efficient than using a map directly,
+// since it uses a special hash function for coordinates.
+// The speed-up is variable, but was ~2x as of mid-2021.
+type EdgeToNumber[T Adder] struct {
+	slowMap map[[2]Coord3D]T
+	fastMap map[uint64]cellForEdgeToNumber[T]
+}
+
+// NewEdgeToNumber creates an empty map.
+func NewEdgeToNumber[T Adder]() *EdgeToNumber[T] {
+	return &EdgeToNumber[T]{fastMap: map[uint64]cellForEdgeToNumber[T]{}}
+}
+
+// Len gets the number of elements in the map.
+func (m *EdgeToNumber[T]) Len() int {
+	if m.fastMap != nil {
+		return len(m.fastMap)
+	} else {
+		return len(m.slowMap)
+	}
+}
+
+// Value is like Load(), but without a second return
+// value.
+func (m *EdgeToNumber[T]) Value(key [2]Coord3D) T {
+	res, _ := m.Load(key)
+	return res
+}
+
+// Load gets the value for the given key.
+//
+// If no value is present, the first return argument is a
+// zero value, and the second is false. Otherwise, the
+// second return value is true.
+func (m *EdgeToNumber[T]) Load(key [2]Coord3D) (T, bool) {
+	if m.fastMap != nil {
+		cell, ok := m.fastMap[hashForEdgeToNumber(key)]
+		if !ok || cell.Key != key {
+			return zeroForEdgeToNumber[T](), false
+		}
+		return cell.Value, true
+	} else {
+		x, y := m.slowMap[key]
+		return x, y
+	}
+}
+
+// Delete removes the key from the map if it exists, and
+// does nothing otherwise.
+func (m *EdgeToNumber[T]) Delete(key [2]Coord3D) {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
+			delete(m.fastMap, hash)
+		}
+	} else {
+		delete(m.slowMap, key)
+	}
+}
+
+// Store assigns the value to the given key, overwriting
+// the previous value for the key if necessary.
+func (m *EdgeToNumber[T]) Store(key [2]Coord3D, value T) {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		cell, ok := m.fastMap[hash]
+		if ok && cell.Key != key {
+			// We must switch to a slow map to store colliding values.
+			m.fastToSlow()
+			m.slowMap[key] = value
+		} else {
+			m.fastMap[hash] = cellForEdgeToNumber[T]{Key: key, Value: value}
+		}
+	} else {
+		m.slowMap[key] = value
+	}
+}
+
+// Add adds x to the value stored for the given key and
+// returns the new value.
+func (m *EdgeToNumber[T]) Add(key [2]Coord3D, x T) T {
+	if m.fastMap != nil {
+		hash := hashForEdgeToNumber(key)
+		cell, ok := m.fastMap[hash]
+		if ok && cell.Key != key {
+			// We must switch to a slow map to store colliding values.
+			m.fastToSlow()
+			return m.Add(key, x)
+		} else {
+			m.fastMap[hash] = cellForEdgeToNumber[T]{Key: key, Value: cell.Value + x}
+			return cell.Value + x
+		}
+	} else {
+		value := m.slowMap[key] + x
+		m.slowMap[key] = value
+		return value
+	}
+}
+
+// KeyRange is like Range, but only iterates over
+// keys, not values.
+func (m *EdgeToNumber[T]) KeyRange(f func(key [2]Coord3D) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Key) {
+				return
+			}
+		}
+	} else {
+		for k := range m.slowMap {
+			if !f(k) {
+				return
+			}
+		}
+	}
+}
+
+// ValueRange is like Range, but only iterates over
+// values only.
+func (m *EdgeToNumber[T]) ValueRange(f func(value T) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Value) {
+				return
+			}
+		}
+	} else {
+		for _, v := range m.slowMap {
+			if !f(v) {
+				return
+			}
+		}
+	}
+}
+
+// Range iterates over the map, calling f successively for
+// each value until it returns false, or all entries are
+// enumerated.
+//
+// It is not safe to modify the map with Store or Delete
+// during enumeration.
+func (m *EdgeToNumber[T]) Range(f func(key [2]Coord3D, value T) bool) {
+	if m.fastMap != nil {
+		for _, cell := range m.fastMap {
+			if !f(cell.Key, cell.Value) {
+				return
+			}
+		}
+	} else {
+		for k, v := range m.slowMap {
+			if !f(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (m *EdgeToNumber[T]) fastToSlow() {
+	m.slowMap = map[[2]Coord3D]T{}
+	for _, cell := range m.fastMap {
+		m.slowMap[cell.Key] = cell.Value
+	}
+	m.fastMap = nil
+}
+
+type cellForEdgeToNumber[T Adder] struct {
+	Key   [2]Coord3D
+	Value T
+}
+
+func hashForEdgeToNumber(c [2]Coord3D) uint64 {
+	h1 := c[0].fastHash()
+	h2 := c[1].fastHash()
+	return uint64(h1) | (uint64(h2) << 32)
+}
+
+func zeroForEdgeToNumber[T any]() T {
+	var e T
+	return e
 }

--- a/model3d/fast_maps.go
+++ b/model3d/fast_maps.go
@@ -3,13 +3,13 @@
 package model3d
 
 // CoordMap implements a map-like interface for
-// mapping Coord3D to interface{}.
+// mapping Coord3D to any.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
 type CoordMap struct {
-	slowMap map[Coord3D]interface{}
+	slowMap map[Coord3D]any
 	fastMap map[uint64]cellForCoordMap
 }
 
@@ -29,7 +29,7 @@ func (m *CoordMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *CoordMap) Value(key Coord3D) interface{} {
+func (m *CoordMap) Value(key Coord3D) any {
 	res, _ := m.Load(key)
 	return res
 }
@@ -39,7 +39,7 @@ func (m *CoordMap) Value(key Coord3D) interface{} {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *CoordMap) Load(key Coord3D) (interface{}, bool) {
+func (m *CoordMap) Load(key Coord3D) (any, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForCoordMap(key)]
 		if !ok || cell.Key != key {
@@ -67,7 +67,7 @@ func (m *CoordMap) Delete(key Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *CoordMap) Store(key Coord3D, value interface{}) {
+func (m *CoordMap) Store(key Coord3D, value any) {
 	if m.fastMap != nil {
 		hash := hashForCoordMap(key)
 		cell, ok := m.fastMap[hash]
@@ -103,7 +103,7 @@ func (m *CoordMap) KeyRange(f func(key Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *CoordMap) ValueRange(f func(value interface{}) bool) {
+func (m *CoordMap) ValueRange(f func(value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -125,7 +125,7 @@ func (m *CoordMap) ValueRange(f func(value interface{}) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *CoordMap) Range(f func(key Coord3D, value interface{}) bool) {
+func (m *CoordMap) Range(f func(key Coord3D, value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -142,7 +142,7 @@ func (m *CoordMap) Range(f func(key Coord3D, value interface{}) bool) {
 }
 
 func (m *CoordMap) fastToSlow() {
-	m.slowMap = map[Coord3D]interface{}{}
+	m.slowMap = map[Coord3D]any{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
@@ -151,7 +151,7 @@ func (m *CoordMap) fastToSlow() {
 
 type cellForCoordMap struct {
 	Key   Coord3D
-	Value interface{}
+	Value any
 }
 
 func hashForCoordMap(c Coord3D) uint64 {
@@ -826,13 +826,13 @@ func hashForCoordToBool(c Coord3D) uint64 {
 }
 
 // EdgeMap implements a map-like interface for
-// mapping [2]Coord3D to interface{}.
+// mapping [2]Coord3D to any.
 //
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
 type EdgeMap struct {
-	slowMap map[[2]Coord3D]interface{}
+	slowMap map[[2]Coord3D]any
 	fastMap map[uint64]cellForEdgeMap
 }
 
@@ -852,7 +852,7 @@ func (m *EdgeMap) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *EdgeMap) Value(key [2]Coord3D) interface{} {
+func (m *EdgeMap) Value(key [2]Coord3D) any {
 	res, _ := m.Load(key)
 	return res
 }
@@ -862,7 +862,7 @@ func (m *EdgeMap) Value(key [2]Coord3D) interface{} {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *EdgeMap) Load(key [2]Coord3D) (interface{}, bool) {
+func (m *EdgeMap) Load(key [2]Coord3D) (any, bool) {
 	if m.fastMap != nil {
 		cell, ok := m.fastMap[hashForEdgeMap(key)]
 		if !ok || cell.Key != key {
@@ -890,7 +890,7 @@ func (m *EdgeMap) Delete(key [2]Coord3D) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *EdgeMap) Store(key [2]Coord3D, value interface{}) {
+func (m *EdgeMap) Store(key [2]Coord3D, value any) {
 	if m.fastMap != nil {
 		hash := hashForEdgeMap(key)
 		cell, ok := m.fastMap[hash]
@@ -926,7 +926,7 @@ func (m *EdgeMap) KeyRange(f func(key [2]Coord3D) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *EdgeMap) ValueRange(f func(value interface{}) bool) {
+func (m *EdgeMap) ValueRange(f func(value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Value) {
@@ -948,7 +948,7 @@ func (m *EdgeMap) ValueRange(f func(value interface{}) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *EdgeMap) Range(f func(key [2]Coord3D, value interface{}) bool) {
+func (m *EdgeMap) Range(f func(key [2]Coord3D, value any) bool) {
 	if m.fastMap != nil {
 		for _, cell := range m.fastMap {
 			if !f(cell.Key, cell.Value) {
@@ -965,7 +965,7 @@ func (m *EdgeMap) Range(f func(key [2]Coord3D, value interface{}) bool) {
 }
 
 func (m *EdgeMap) fastToSlow() {
-	m.slowMap = map[[2]Coord3D]interface{}{}
+	m.slowMap = map[[2]Coord3D]any{}
 	for _, cell := range m.fastMap {
 		m.slowMap[cell.Key] = cell.Value
 	}
@@ -974,7 +974,7 @@ func (m *EdgeMap) fastToSlow() {
 
 type cellForEdgeMap struct {
 	Key   [2]Coord3D
-	Value interface{}
+	Value any
 }
 
 func hashForEdgeMap(c [2]Coord3D) uint64 {

--- a/model3d/fast_maps_test.go
+++ b/model3d/fast_maps_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCoordMap(t *testing.T) {
-	cm := NewCoordMap()
+	cm := NewCoordMap[any]()
 
 	checkBehavior := func() {
 		baseline := map[Coord3D]int{}
@@ -94,7 +94,7 @@ func TestCoordMap(t *testing.T) {
 
 func BenchmarkCoordMap(b *testing.B) {
 	b.Run("Fast", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c := NewCoord3DRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -103,7 +103,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Slow", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c1, c2 := findHashCollision()
 		cm.Store(c1, 1337)
 		cm.Store(c2, 1337)
@@ -117,7 +117,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Baseline", func(b *testing.B) {
-		cm := map[Coord3D]any{}
+		cm := map[Coord3D]int{}
 		c := NewCoord3DRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/model3d/fast_maps_test.go
+++ b/model3d/fast_maps_test.go
@@ -42,7 +42,7 @@ func TestCoordMap(t *testing.T) {
 				t.Fatalf("should have length %d but got %d", len(baseline), cm.Len())
 			}
 			count := 0
-			cm.Range(func(k Coord3D, v interface{}) bool {
+			cm.Range(func(k Coord3D, v any) bool {
 				count++
 				if baseline[k] != v {
 					t.Fatal("invalid entry")
@@ -117,7 +117,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
 	b.Run("Baseline", func(b *testing.B) {
-		cm := map[Coord3D]interface{}{}
+		cm := map[Coord3D]any{}
 		c := NewCoord3DRandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/model3d/mc.go
+++ b/model3d/mc.go
@@ -54,9 +54,9 @@ func MarchingCubesSearch(s Solid, delta float64, iters int) *Mesh {
 // in addition to a mesh, it returns a mapping from each
 // vertex to a nearby point which is known to be contained
 // within the solid.
-func MarchingCubesInterior(s Solid, delta float64, iters int) (*Mesh, *CoordToCoord) {
+func MarchingCubesInterior(s Solid, delta float64, iters int) (*Mesh, *CoordMap[Coord3D]) {
 	mesh := MarchingCubes(s, delta)
-	interior := NewCoordToCoord()
+	interior := NewCoordMap[Coord3D]()
 	mcSearch(s, delta, iters, mesh, interior)
 	return mesh, interior
 }
@@ -183,7 +183,7 @@ func MarchingCubesC2F(s Solid, bigDelta, smallDelta, extraSpace float64, iters i
 	return MarchingCubesSearchFilter(s, filter, smallDelta, iters)
 }
 
-func mcSearch(s Solid, delta float64, iters int, mesh *Mesh, interior *CoordToCoord) {
+func mcSearch(s Solid, delta float64, iters int, mesh *Mesh, interior *CoordMap[Coord3D]) {
 	if iters == 0 && interior == nil {
 		return
 	}

--- a/model3d/mesh_ops.go
+++ b/model3d/mesh_ops.go
@@ -143,8 +143,8 @@ func (m *Mesh) SmoothAreas(stepSize float64, iters int) *Mesh {
 // described in
 // "A Comparison of Algorithms for Vertex Normal Computations"
 // http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.99.2846&rep=rep1&type=pdf.
-func (m *Mesh) VertexNormals() *CoordToCoord {
-	sums := NewCoordToCoord()
+func (m *Mesh) VertexNormals() *CoordMap[Coord3D] {
+	sums := NewCoordMap[Coord3D]()
 	m.Iterate(func(t *Triangle) {
 		edges := [3]Coord3D{
 			t[0].Sub(t[1]).Normalize(),
@@ -160,7 +160,7 @@ func (m *Mesh) VertexNormals() *CoordToCoord {
 			sums.Store(c, cur.Add(normal.Scale(theta)))
 		}
 	})
-	normalized := NewCoordToCoord()
+	normalized := NewCoordMap[Coord3D]()
 	sums.Range(func(k, v Coord3D) bool {
 		normalized.Store(k, v.Normalize())
 		return true
@@ -341,7 +341,7 @@ type equivalenceClass struct {
 // NeedsRepair checks if every edge touches exactly two
 // triangles. If not, NeedsRepair returns true.
 func (m *Mesh) NeedsRepair() bool {
-	counts := NewEdgeToInt()
+	counts := NewEdgeToNumber[int]()
 	for face := range m.faces {
 		for i := 0; i < 3; i++ {
 			seg := NewSegment(face[i], face[(i+1)%3])

--- a/model3d/mesh_test.go
+++ b/model3d/mesh_test.go
@@ -169,7 +169,7 @@ func BenchmarkVertexToFace(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mesh.getVertexToFace()
-		var v2f *CoordToFaces
+		var v2f *CoordToSlice[*Triangle]
 		mesh.vertexToFace.Store(v2f)
 	}
 }

--- a/model3d/smooth.go
+++ b/model3d/smooth.go
@@ -166,7 +166,7 @@ func newIndexMesh(m *Mesh) *indexMesh {
 		Coords:    make([]Coord3D, 0, capacity),
 		Triangles: make([][3]int, 0, len(m.faces)),
 	}
-	coordToIdx := NewCoordToInt()
+	coordToIdx := NewCoordMap[int]()
 
 	m.Iterate(func(t *Triangle) {
 		var triangle [3]int

--- a/model3d/solid.go
+++ b/model3d/solid.go
@@ -100,23 +100,20 @@ func (j JoinedSolid) Contains(c Coord3D) bool {
 // Optimize creates a version of the solid that is faster
 // when joining a large number of smaller solids.
 func (j JoinedSolid) Optimize() Solid {
-	bounders := make([]Bounder, len(j))
-	for i, s := range j {
-		bounders[i] = s
-	}
-	GroupBounders(bounders)
-	return groupedBoundersToSolid(bounders)
+	grouped := append([]Solid{}, j...)
+	GroupBounders(grouped)
+	return groupedSolidsToSolid(grouped)
 }
 
-func groupedBoundersToSolid(bs []Bounder) Solid {
-	if len(bs) == 1 {
-		return CacheSolidBounds(bs[0].(Solid))
+func groupedSolidsToSolid(s []Solid) Solid {
+	if len(s) == 1 {
+		return CacheSolidBounds(s[0].(Solid))
 	}
-	firstHalf := bs[:len(bs)/2]
-	secondHalf := bs[len(bs)/2:]
+	firstHalf := s[:len(s)/2]
+	secondHalf := s[len(s)/2:]
 	return CacheSolidBounds(JoinedSolid{
-		groupedBoundersToSolid(firstHalf),
-		groupedBoundersToSolid(secondHalf),
+		groupedSolidsToSolid(firstHalf),
+		groupedSolidsToSolid(secondHalf),
 	})
 }
 
@@ -525,8 +522,11 @@ func NewSolidMux(solids []Solid) *SolidMux {
 	if len(solids) == 0 {
 		return &SolidMux{}
 	}
-	bounders := make([]Bounder, len(solids))
-	bounderToIndex := map[Bounder]int{}
+	// Group Rects instead of Solids so that we know
+	// we can use the bounder as a key in a map to
+	// track the index.
+	bounders := make([]*Rect, len(solids))
+	bounderToIndex := map[*Rect]int{}
 	for i, s := range solids {
 		bounders[i] = BoundsRect(s)
 		bounderToIndex[bounders[i]] = i

--- a/model3d/util_test.go
+++ b/model3d/util_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Failer interface {
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 }
 
 // ValidateMesh checks if m is manifold and has correct normals.

--- a/render3d/concurrency.go
+++ b/render3d/concurrency.go
@@ -8,7 +8,7 @@ import (
 
 type goInfo struct {
 	Gen   *rand.Rand
-	Extra interface{}
+	Extra any
 }
 
 // mapCoordinates calls f with every coordinate in an

--- a/render3d/helpers.go
+++ b/render3d/helpers.go
@@ -68,7 +68,7 @@ func (c *colorFuncObject) Cast(r *model3d.Ray) (model3d.RayCollision, Material, 
 // The colorFunc is used to color the object's material.
 // If colorFunc is used, a default yellow color is used,
 // unless the object already has an associated material.
-func Objectify(obj interface{}, colorFunc ColorFunc) Object {
+func Objectify(obj any, colorFunc ColorFunc) Object {
 	switch obj := obj.(type) {
 	case Object:
 		return &colorFuncObject{Object: obj, ColorFunc: colorFunc}
@@ -102,7 +102,7 @@ func Objectify(obj interface{}, colorFunc ColorFunc) Object {
 //
 // If colorFunc is non-nil, it is used to determine the
 // color for the visible parts of the model.
-func SaveRendering(path string, obj interface{}, origin model3d.Coord3D, width, height int,
+func SaveRendering(path string, obj any, origin model3d.Coord3D, width, height int,
 	colorFunc ColorFunc) error {
 	object := Objectify(obj, colorFunc)
 	image := NewImage(width*helperAntialias, height*helperAntialias)
@@ -130,7 +130,7 @@ func SaveRendering(path string, obj interface{}, origin model3d.Coord3D, width, 
 //
 // If colorFunc is non-nil, it is used to determine the
 // color for the visible parts of the model.
-func SaveRandomGrid(path string, obj interface{}, rows, cols, imgSize int,
+func SaveRandomGrid(path string, obj any, rows, cols, imgSize int,
 	colorFunc ColorFunc) error {
 	object := Objectify(obj, colorFunc)
 	fullOutput := NewImage(cols*imgSize, rows*imgSize)
@@ -167,7 +167,7 @@ func SaveRandomGrid(path string, obj interface{}, rows, cols, imgSize int,
 // The cameraDir specifies the direction (from the center
 // of the object) from which the camera will be extended
 // until it can see the entire object.
-func SaveRotatingGIF(path string, obj interface{}, axis, cameraDir model3d.Coord3D,
+func SaveRotatingGIF(path string, obj any, axis, cameraDir model3d.Coord3D,
 	imgSize, frames int, fps float64, colorFunc ColorFunc) error {
 	object := Objectify(obj, colorFunc)
 	min, max := object.Min(), object.Max()

--- a/templates/bvh.template
+++ b/templates/bvh.template
@@ -5,39 +5,42 @@ import (
 	"sort"
 )
 
-// GeneralBVH represents a (possibly unbalanced)
-// axis-aligned bounding box hierarchy.
+// BVH represents a (possibly unbalanced) axis-aligned
+// bounding box hierarchy.
 //
-// A GeneralBVH can store arbitrary Bounders.
-// For a mesh-specific version, see BVH.
-type GeneralBVH struct {
+// A BVH can be used to accelerate collision detection.
+// See BVHToCollider() for more details.
+//
+// A BVH node is either a leaf (a single Bounder), or a
+// branch with two or more children.
+type BVH[B Bounder] struct {
 	// Leaf, if non-nil, is the final bounder.
-	Leaf Bounder
+	Leaf B
 
 	// Branch, if Leaf is nil, points to two children.
-	Branch []*GeneralBVH
+	Branch []*BVH[B]
 }
 
-// NewGeneralBVHAreaDensity creates a GeneralBVH by
-// minimizing the product of each bounding box's {{if .model2d}}perimeter{{else}}area{{end}} with
+// NewBVHAreaDensity creates a BVH by minimizing
+// the product of each bounding box's {{if .model2d}}perimeter{{else}}area{{end}} with
 // the number of objects contained in the bounding box at
 // each branch.
 //
 // This is good for efficient ray collision detection.
-func NewGeneralBVHAreaDensity(objects []Bounder) *GeneralBVH {
-	return newGeneralBVH(sortBounders(objects), make([]float64, len(objects)),
-		areaDensityBVHSplit)
+func NewBVHAreaDensity[B Bounder](objects []B) *BVH[B] {
+	return newBVH(sortBounders(objects), make([]float64, len(objects)),
+		areaDensityBVHSplit[B])
 }
 
-func newGeneralBVH(sortedBounders [{{.numDims}}][]*flaggedBounder, cache []float64,
-	splitter func([]*flaggedBounder, []float64) (int, float64)) *GeneralBVH {
+func newBVH[B Bounder](sortedBounders [{{.numDims}}][]*flaggedBounder[B], cache []float64,
+	splitter func([]*flaggedBounder[B], []float64) (int, float64)) *BVH[B] {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 0 {
 		panic("empty sorted objects")
 	} else if numObjs == 1 {
-		return &GeneralBVH{Leaf: sortedBounders[0][0].B}
+		return &BVH[B]{Leaf: sortedBounders[0][0].B}
 	} else if numObjs == 2 {
-		return &GeneralBVH{Branch: []*GeneralBVH{
+		return &BVH[B]{Branch: []*BVH[B]{
 			{Leaf: sortedBounders[0][0].B},
 			{Leaf: sortedBounders[0][1].B},
 		}}
@@ -49,7 +52,7 @@ func newGeneralBVH(sortedBounders [{{.numDims}}][]*flaggedBounder, cache []float
 	zIndex, zScore := splitter(sortedBounders[2], cache)
 	{{- end}}
 
-	var split [2][{{.numDims}}][]*flaggedBounder
+	var split [2][{{.numDims}}][]*flaggedBounder[B]
 	{{if .model2d -}}
 	if xScore < yScore {
 		split = splitBounders(sortedBounders, 0, xIndex)
@@ -65,48 +68,12 @@ func newGeneralBVH(sortedBounders [{{.numDims}}][]*flaggedBounder, cache []float
 		split = splitBounders(sortedBounders, 2, zIndex)
 	}
 	{{- end}}
-	return &GeneralBVH{
-		Branch: []*GeneralBVH{
-			newGeneralBVH(split[0], cache, splitter),
-			newGeneralBVH(split[1], cache, splitter),
+	return &BVH[B]{
+		Branch: []*BVH[B]{
+			newBVH(split[0], cache, splitter),
+			newBVH(split[1], cache, splitter),
 		},
 	}
-}
-
-// BVH represents a (possibly unbalanced) axis-aligned
-// bounding box hierarchy of {{.faceName}}s.
-//
-// A BVH can be used to accelerate collision detection.
-// See BVHToCollider() for more details.
-//
-// A BVH node is either a leaf (a single {{.faceName}}), or a branch
-// with two or more children.
-//
-// For a more generic BVH that supports any object rather
-// than just {{.faceName}}s, see GeneralBVH.
-type BVH struct {
-	// Leaf, if non-nil, is the sole object in this node.
-	Leaf *{{.faceType}}
-
-	// Branch, if Leaf is nil, points to two children.
-	Branch []*BVH
-}
-
-// NewBVHAreaDensity is like NewGeneralBVHAreaDensity but
-// for {{.faceName}}s.
-func NewBVHAreaDensity(objs []*{{.faceType}}) *BVH {
-	return generalBVHToBVH(NewGeneralBVHAreaDensity(facesToBounders(objs)))
-}
-
-func generalBVHToBVH(g *GeneralBVH) *BVH {
-	if g.Leaf != nil {
-		return &BVH{Leaf: g.Leaf.(*{{.faceType}})}
-	}
-	res := &BVH{Branch: make([]*BVH, len(g.Branch))}
-	for i, g1 := range g.Branch {
-		res.Branch[i] = generalBVHToBVH(g1)
-	}
-	return res
 }
 
 // areaDensityBVHSplit chooses a split index that
@@ -117,7 +84,7 @@ func generalBVHToBVH(g *GeneralBVH) *BVH {
 // the number of {{.faceName}}s.
 //
 // The cache must contain at least len(faces) entries.
-func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64) {
+func areaDensityBVHSplit[B Bounder](faces []*flaggedBounder[B], cache []float64) (int, float64) {
 	// Fill the cache with scores going in the other
 	// direction.
 	min, max := faces[len(faces)-1].Min, faces[len(faces)-1].Max
@@ -148,6 +115,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 
 // Group{{.faceType}}s is like GroupBounders, but for {{.faceName}}s
 // in particular.
+// This is now equivalent to GroupBounders(faces).
 //
 // This can be used to prepare models for being turned
 // into a collider efficiently, or for storing meshes in
@@ -156,11 +124,7 @@ func areaDensityBVHSplit(faces []*flaggedBounder, cache []float64) (int, float64
 // The resulting hierarchy can be passed directly to
 // Grouped{{.faceType}}sToCollider().
 func Group{{.faceType}}s(faces []*{{.faceType}}) {
-	bs := facesToBounders(faces)
-	groupBounders(sortBounders(bs), bs)
-	for i, b := range bs {
-		faces[i] = b.(*{{.faceType}})
-	}
+	GroupBounders(faces)
 }
 
 // GroupBounders sorts a slice of objects into a balanced
@@ -172,11 +136,11 @@ func Group{{.faceType}}s(faces []*{{.faceType}}) {
 // To cut a slice in half, divide the length by two, round
 // down, and use the result as the start index for the
 // second half.
-func GroupBounders(objects []Bounder) {
+func GroupBounders[B Bounder](objects []B) {
 	groupBounders(sortBounders(objects), objects)
 }
 
-func groupBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, output []Bounder) {
+func groupBounders[B Bounder](sortedBounders [{{.numDims}}][]*flaggedBounder[B], output []B) {
 	numObjs := len(sortedBounders[0])
 	if numObjs == 2 {
 		// The area-based splitting criterion doesn't
@@ -199,12 +163,13 @@ func groupBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, output []Boun
 	groupBounders(separated[1], output[midIdx:])
 }
 
-func splitBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, axis, midIdx int) [2][{{.numDims}}][]*flaggedBounder {
+func splitBounders[B Bounder](sortedBounders [{{.numDims}}][]*flaggedBounder[B],
+	axis, midIdx int) [2][{{.numDims}}][]*flaggedBounder[B] {
 	for i, b := range sortedBounders[axis] {
 		b.Flag = i < midIdx
 	}
 
-	separated := [{{.numDims}}][]*flaggedBounder{}
+	separated := [{{.numDims}}][]*flaggedBounder[B]{}
 	separated[axis] = sortedBounders[axis]
 
 	numObjs := len(sortedBounders[0])
@@ -212,7 +177,7 @@ func splitBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, axis, midIdx 
 		if newAxis == axis {
 			continue
 		}
-		sep := make([]*flaggedBounder, numObjs)
+		sep := make([]*flaggedBounder[B], numObjs)
 		idx0 := 0
 		idx1 := midIdx
 		for _, b := range sortedBounders[newAxis] {
@@ -227,7 +192,7 @@ func splitBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, axis, midIdx 
 		separated[newAxis] = sep
 	}
 
-	return [2][{{.numDims}}][]*flaggedBounder{
+	return [2][{{.numDims}}][]*flaggedBounder[B]{
 		{
 			separated[0][:midIdx],
 			separated[1][:midIdx],
@@ -245,7 +210,7 @@ func splitBounders(sortedBounders [{{.numDims}}][]*flaggedBounder, axis, midIdx 
 	}
 }
 
-func bestSplitAxis(sortedBounders [{{.numDims}}][]*flaggedBounder) int {
+func bestSplitAxis[B Bounder](sortedBounders [{{.numDims}}][]*flaggedBounder[B]) int {
 	midIdx := len(sortedBounders[0]) / 2
 
 	areaForAxis := func(axis int) float64 {
@@ -265,13 +230,13 @@ func bestSplitAxis(sortedBounders [{{.numDims}}][]*flaggedBounder) int {
 	return axis
 }
 
-func sortBounders(bs []Bounder) [{{.numDims}}][]*flaggedBounder {
+func sortBounders[B Bounder](bs []B) [{{.numDims}}][]*flaggedBounder[B] {
 	// Allocate all of the flaggedBounders at once all
 	// next to each other in memory.
-	flagged := make([]flaggedBounder, len(bs))
+	flagged := make([]flaggedBounder[B], len(bs))
 	for i, b := range bs {
 		min, max := b.Min(), b.Max()
-		flagged[i] = flaggedBounder{
+		flagged[i] = flaggedBounder[B]{
 			B:   b,
 			Min: min,
 			Max: max,
@@ -279,9 +244,9 @@ func sortBounders(bs []Bounder) [{{.numDims}}][]*flaggedBounder {
 		}
 	}
 
-	var result [{{.numDims}}][]*flaggedBounder
+	var result [{{.numDims}}][]*flaggedBounder[B]
 	for axis := range result {
-		bsCopy := make([]*flaggedBounder, len(flagged))
+		bsCopy := make([]*flaggedBounder[B], len(flagged))
 		for i := range flagged {
 			bsCopy[i] = &flagged[i]
 		}
@@ -305,7 +270,7 @@ func sortBounders(bs []Bounder) [{{.numDims}}][]*flaggedBounder {
 	return result
 }
 
-func multipleBoundsArea(bs []*flaggedBounder) float64 {
+func multipleBoundsArea[B Bounder](bs []*flaggedBounder[B]) float64 {
 	min, max := bs[0].Min, bs[0].Max
 	for i := 1; i < len(bs); i++ {
 		b := bs[i]
@@ -350,8 +315,8 @@ func boundsArea(min, max {{.coordType}}) float64 {
 	{{- end}}
 }
 
-type flaggedBounder struct {
-	B    Bounder
+type flaggedBounder[B Bounder] struct {
+	B    B
 	Min  {{.coordType}}
 	Max  {{.coordType}}
 	Mid  {{.coordType}}
@@ -413,12 +378,4 @@ func rayCollisionWithBounds(r *Ray, min, max {{.coordType}}) (minFrac, maxFrac f
 		}
 	}
 	return
-}
-
-func facesToBounders(faces []*{{.faceType}}) []Bounder {
-	bs := make([]Bounder, len(faces))
-	for i, t := range faces {
-		bs[i] = t
-	}
-	return bs
 }

--- a/templates/fast_maps.template
+++ b/templates/fast_maps.template
@@ -1,5 +1,11 @@
 package {{ .package }}
 
+type Adder interface {
+    ~int | ~int8 | ~int16 | ~int32 | ~int64 |
+        ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+        ~float32 | ~float64 | ~complex64 | ~complex128
+}
+
 {{define "fastMap" -}}
 // {{.mapType}} implements a map-like interface for
 // mapping {{.keyType}} to {{.elemType}}.
@@ -7,18 +13,18 @@ package {{ .package }}
 // This can be more efficient than using a map directly,
 // since it uses a special hash function for coordinates.
 // The speed-up is variable, but was ~2x as of mid-2021.
-type {{.mapType}} struct {
+type {{.mapType}}[T {{.constraint}}] struct {
     slowMap    map[{{.keyType}}]{{.elemType}}
-    fastMap    map[uint64]cellFor{{.mapType}}
+    fastMap    map[uint64]cellFor{{.mapType}}[T]
 }
 
 // New{{.mapType}} creates an empty map.
-func New{{.mapType}}() *{{.mapType}} {
-    return &{{.mapType}}{fastMap: map[uint64]cellFor{{.mapType}}{}}
+func New{{.mapType}}[T {{.constraint}}]() *{{.mapType}}[T] {
+    return &{{.mapType}}[T]{fastMap: map[uint64]cellFor{{.mapType}}[T]{}}
 }
 
 // Len gets the number of elements in the map.
-func (m *{{.mapType}}) Len() int {
+func (m *{{.mapType}}[T]) Len() int {
     if m.fastMap != nil {
         return len(m.fastMap)
     } else {
@@ -28,7 +34,7 @@ func (m *{{.mapType}}) Len() int {
 
 // Value is like Load(), but without a second return
 // value.
-func (m *{{.mapType}}) Value(key {{.keyType}}) {{.elemType}} {
+func (m *{{.mapType}}[T]) Value(key {{.keyType}}) {{.elemType}} {
     res, _ := m.Load(key)
     return res
 }
@@ -38,11 +44,11 @@ func (m *{{.mapType}}) Value(key {{.keyType}}) {{.elemType}} {
 // If no value is present, the first return argument is a
 // zero value, and the second is false. Otherwise, the
 // second return value is true.
-func (m *{{.mapType}}) Load(key {{.keyType}}) ({{.elemType}}, bool) {
+func (m *{{.mapType}}[T]) Load(key {{.keyType}}) ({{.elemType}}, bool) {
     if m.fastMap != nil {
         cell, ok := m.fastMap[hashFor{{.mapType}}(key)]
         if !ok || cell.Key != key {
-            return {{.zeroVal}}, false
+            return zeroFor{{.mapType}}[T](), false
         }
         return cell.Value, true
     } else {
@@ -53,7 +59,7 @@ func (m *{{.mapType}}) Load(key {{.keyType}}) ({{.elemType}}, bool) {
 
 // Delete removes the key from the map if it exists, and
 // does nothing otherwise.
-func (m *{{.mapType}}) Delete(key {{.keyType}}) {
+func (m *{{.mapType}}[T]) Delete(key {{.keyType}}) {
     if m.fastMap != nil {
         hash := hashFor{{.mapType}}(key)
         if cell, ok := m.fastMap[hash]; ok && cell.Key == key {
@@ -66,7 +72,7 @@ func (m *{{.mapType}}) Delete(key {{.keyType}}) {
 
 // Store assigns the value to the given key, overwriting
 // the previous value for the key if necessary.
-func (m *{{.mapType}}) Store(key {{.keyType}}, value {{.elemType}}) {
+func (m *{{.mapType}}[T]) Store(key {{.keyType}}, value {{.elemType}}) {
     if m.fastMap != nil {
         hash := hashFor{{.mapType}}(key)
         cell, ok := m.fastMap[hash]
@@ -75,17 +81,17 @@ func (m *{{.mapType}}) Store(key {{.keyType}}, value {{.elemType}}) {
             m.fastToSlow()
             m.slowMap[key] = value
         } else {
-            m.fastMap[hash] = cellFor{{.mapType}}{Key: key, Value: value}
+            m.fastMap[hash] = cellFor{{.mapType}}[T]{Key: key, Value: value}
         }
     } else {
         m.slowMap[key] = value
     }
 }
 
-{{if eq .elemType "int" -}}
+{{if eq .constraint "Adder" -}}
 // Add adds x to the value stored for the given key and
 // returns the new value.
-func (m *{{.mapType}}) Add(key {{.keyType}}, x {{.elemType}}) int {
+func (m *{{.mapType}}[T]) Add(key {{.keyType}}, x {{.elemType}}) {{.elemType}} {
     if m.fastMap != nil {
         hash := hashFor{{.mapType}}(key)
         cell, ok := m.fastMap[hash]
@@ -94,7 +100,7 @@ func (m *{{.mapType}}) Add(key {{.keyType}}, x {{.elemType}}) int {
             m.fastToSlow()
             return m.Add(key, x)
         } else {
-            m.fastMap[hash] = cellFor{{.mapType}}{Key: key, Value: cell.Value + x}
+            m.fastMap[hash] = cellFor{{.mapType}}[T]{Key: key, Value: cell.Value + x}
             return cell.Value + x
         }
     } else {
@@ -106,7 +112,7 @@ func (m *{{.mapType}}) Add(key {{.keyType}}, x {{.elemType}}) int {
 {{- else if hasprefix .elemType "[]" -}}
 // Append appends x to the value stored for the given key
 // and returns the new value.
-func (m *{{.mapType}}) Append(key {{.keyType}}, x {{slice .elemType 2}}) {{.elemType}} {
+func (m *{{.mapType}}[T]) Append(key {{.keyType}}, x {{slice .elemType 2}}) {{.elemType}} {
     if m.fastMap != nil {
         hash := hashFor{{.mapType}}(key)
         cell, ok := m.fastMap[hash]
@@ -116,7 +122,7 @@ func (m *{{.mapType}}) Append(key {{.keyType}}, x {{slice .elemType 2}}) {{.elem
             return m.Append(key, x)
         } else {
             value := append(cell.Value, x)
-            m.fastMap[hash] = cellFor{{.mapType}}{Key: key, Value: value}
+            m.fastMap[hash] = cellFor{{.mapType}}[T]{Key: key, Value: value}
             return value
         }
     } else {
@@ -129,7 +135,7 @@ func (m *{{.mapType}}) Append(key {{.keyType}}, x {{slice .elemType 2}}) {{.elem
 
 // KeyRange is like Range, but only iterates over
 // keys, not values.
-func (m *{{.mapType}}) KeyRange(f func(key {{.keyType}}) bool) {
+func (m *{{.mapType}}[T]) KeyRange(f func(key {{.keyType}}) bool) {
     if m.fastMap != nil {
         for _, cell := range m.fastMap {
             if !f(cell.Key) {
@@ -147,7 +153,7 @@ func (m *{{.mapType}}) KeyRange(f func(key {{.keyType}}) bool) {
 
 // ValueRange is like Range, but only iterates over
 // values only.
-func (m *{{.mapType}}) ValueRange(f func(value {{.elemType}}) bool) {
+func (m *{{.mapType}}[T]) ValueRange(f func(value {{.elemType}}) bool) {
     if m.fastMap != nil {
         for _, cell := range m.fastMap {
             if !f(cell.Value) {
@@ -169,7 +175,7 @@ func (m *{{.mapType}}) ValueRange(f func(value {{.elemType}}) bool) {
 //
 // It is not safe to modify the map with Store or Delete
 // during enumeration.
-func (m *{{.mapType}}) Range(f func(key {{.keyType}}, value {{.elemType}}) bool) {
+func (m *{{.mapType}}[T]) Range(f func(key {{.keyType}}, value {{.elemType}}) bool) {
     if m.fastMap != nil {
         for _, cell := range m.fastMap {
             if !f(cell.Key, cell.Value) {
@@ -185,7 +191,7 @@ func (m *{{.mapType}}) Range(f func(key {{.keyType}}, value {{.elemType}}) bool)
     }
 }
 
-func (m *{{.mapType}}) fastToSlow() {
+func (m *{{.mapType}}[T]) fastToSlow() {
     m.slowMap = map[{{.keyType}}]{{.elemType}}{}
     for _, cell := range m.fastMap {
         m.slowMap[cell.Key] = cell.Value
@@ -193,7 +199,7 @@ func (m *{{.mapType}}) fastToSlow() {
     m.fastMap = nil
 }
 
-type cellFor{{.mapType}} struct {
+type cellFor{{.mapType}}[T {{.constraint}}] struct {
     Key   {{.keyType}}
     Value {{.elemType}}
 }
@@ -209,15 +215,17 @@ func hashFor{{.mapType}}(c {{.keyType}}) uint64 {
     return uint64(h1) | (uint64(h2) << 32)
 }
 {{- end}}
+
+func zeroFor{{.mapType}}[T any]() {{.elemType}} {
+    var e {{.elemType}}
+    return e
+}
 {{end -}}
 
-{{- template "fastMap" mkargs . "mapType" "CoordMap" "keyType" .coordType "elemType" "any" "zeroVal" "nil" -}}
-{{- template "fastMap" mkargs . "mapType" "CoordToFaces" "keyType" .coordType "elemType" (cat "[]*" .faceType) "zeroVal" "nil" -}}
-{{- template "fastMap" mkargs . "mapType" "CoordToCoord" "keyType" .coordType "elemType" .coordType "zeroVal" (cat .coordType "{}") -}}
-{{- template "fastMap" mkargs . "mapType" "CoordToInt" "keyType" .coordType "elemType" "int" "zeroVal" "0" -}}
-{{- template "fastMap" mkargs . "mapType" "CoordToBool" "keyType" .coordType "elemType" "bool" "zeroVal" "false" -}}
+{{- template "fastMap" mkargs . "mapType" "CoordMap" "keyType" .coordType "elemType" "T" "constraint" "any" -}}
+{{- template "fastMap" mkargs . "mapType" "CoordToSlice" "keyType" .coordType "elemType" "[]T" "constraint" "any" -}}
+{{- template "fastMap" mkargs . "mapType" "CoordToNumber" "keyType" .coordType "elemType" "T" "constraint" "Adder" -}}
 
-{{- template "fastMap" mkargs . "mapType" "EdgeMap" "keyType" (cat "[2]" .coordType) "elemType" "any" "zeroVal" "nil" -}}
-{{- template "fastMap" mkargs . "mapType" "EdgeToBool" "keyType" (cat "[2]" .coordType) "elemType" "bool" "zeroVal" "false" -}}
-{{- template "fastMap" mkargs . "mapType" "EdgeToInt" "keyType" (cat "[2]" .coordType) "elemType" "int" "zeroVal" "0" -}}
-{{- template "fastMap" mkargs . "mapType" "EdgeToFaces" "keyType" (cat "[2]" .coordType) "elemType" (cat "[]*" .faceType) "zeroVal" "nil" -}}
+{{- template "fastMap" mkargs . "mapType" "EdgeMap" "keyType" (cat "[2]" .coordType) "elemType" "T" "constraint" "any" -}}
+{{- template "fastMap" mkargs . "mapType" "EdgeToSlice" "keyType" (cat "[2]" .coordType) "elemType" "[]T" "constraint" "any" -}}
+{{- template "fastMap" mkargs . "mapType" "EdgeToNumber" "keyType" (cat "[2]" .coordType) "elemType" "T" "constraint" "Adder" -}}

--- a/templates/fast_maps.template
+++ b/templates/fast_maps.template
@@ -211,13 +211,13 @@ func hashFor{{.mapType}}(c {{.keyType}}) uint64 {
 {{- end}}
 {{end -}}
 
-{{- template "fastMap" mkargs . "mapType" "CoordMap" "keyType" .coordType "elemType" "interface{}" "zeroVal" "nil" -}}
+{{- template "fastMap" mkargs . "mapType" "CoordMap" "keyType" .coordType "elemType" "any" "zeroVal" "nil" -}}
 {{- template "fastMap" mkargs . "mapType" "CoordToFaces" "keyType" .coordType "elemType" (cat "[]*" .faceType) "zeroVal" "nil" -}}
 {{- template "fastMap" mkargs . "mapType" "CoordToCoord" "keyType" .coordType "elemType" .coordType "zeroVal" (cat .coordType "{}") -}}
 {{- template "fastMap" mkargs . "mapType" "CoordToInt" "keyType" .coordType "elemType" "int" "zeroVal" "0" -}}
 {{- template "fastMap" mkargs . "mapType" "CoordToBool" "keyType" .coordType "elemType" "bool" "zeroVal" "false" -}}
 
-{{- template "fastMap" mkargs . "mapType" "EdgeMap" "keyType" (cat "[2]" .coordType) "elemType" "interface{}" "zeroVal" "nil" -}}
+{{- template "fastMap" mkargs . "mapType" "EdgeMap" "keyType" (cat "[2]" .coordType) "elemType" "any" "zeroVal" "nil" -}}
 {{- template "fastMap" mkargs . "mapType" "EdgeToBool" "keyType" (cat "[2]" .coordType) "elemType" "bool" "zeroVal" "false" -}}
 {{- template "fastMap" mkargs . "mapType" "EdgeToInt" "keyType" (cat "[2]" .coordType) "elemType" "int" "zeroVal" "0" -}}
 {{- template "fastMap" mkargs . "mapType" "EdgeToFaces" "keyType" (cat "[2]" .coordType) "elemType" (cat "[]*" .faceType) "zeroVal" "nil" -}}

--- a/templates/fast_maps_test.template
+++ b/templates/fast_maps_test.template
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCoordMap(t *testing.T) {
-    cm := NewCoordMap()
+    cm := NewCoordMap[any]()
 
     checkBehavior := func() {
         baseline := map[{{.coordType}}]int{}
@@ -92,7 +92,7 @@ func TestCoordMap(t *testing.T) {
 
 func BenchmarkCoordMap(b *testing.B) {
 	b.Run("Fast", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c := New{{.coordType}}RandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -101,7 +101,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
     b.Run("Slow", func(b *testing.B) {
-		cm := NewCoordMap()
+		cm := NewCoordMap[int]()
 		c1, c2 := findHashCollision()
 		cm.Store(c1, 1337)
 		cm.Store(c2, 1337)
@@ -115,7 +115,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
     b.Run("Baseline", func(b *testing.B) {
-        cm := map[{{.coordType}}]any{}
+        cm := map[{{.coordType}}]int{}
 		c := New{{.coordType}}RandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/templates/fast_maps_test.template
+++ b/templates/fast_maps_test.template
@@ -40,7 +40,7 @@ func TestCoordMap(t *testing.T) {
                 t.Fatalf("should have length %d but got %d", len(baseline), cm.Len())
             }
             count := 0
-            cm.Range(func(k {{.coordType}}, v interface{}) bool {
+            cm.Range(func(k {{.coordType}}, v any) bool {
                 count++
                 if baseline[k] != v {
                     t.Fatal("invalid entry")
@@ -115,7 +115,7 @@ func BenchmarkCoordMap(b *testing.B) {
 		}
 	})
     b.Run("Baseline", func(b *testing.B) {
-        cm := map[{{.coordType}}]interface{}{}
+        cm := map[{{.coordType}}]any{}
 		c := New{{.coordType}}RandNorm()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/templates/mesh.template
+++ b/templates/mesh.template
@@ -47,7 +47,7 @@ import (
 type Mesh struct {
 	faces map[*{{.faceType}}]bool
 
-	// Stores a *CoordToFaces
+	// Stores a *CoordToSlice[*{{.faceType}}]
 	vertexToFace  atomic.Value
 	v2fCreateLock sync.Mutex
 }
@@ -464,7 +464,7 @@ func (m *Mesh) Remove(f *{{.faceType}}) {
 	}
 }
 
-func (m *Mesh) removeFaceFromVertex(v2f *CoordToFaces, f *{{.faceType}}, p {{.coordType}}) {
+func (m *Mesh) removeFaceFromVertex(v2f *CoordToSlice[*{{.faceType}}], f *{{.faceType}}, p {{.coordType}}) {
 	s := v2f.Value(p)
 	for i, f1 := range s {
 		if f1 == f {
@@ -634,7 +634,7 @@ func (m *Mesh) Rotate(axis {{.coordType}}, angle float64) *Mesh {
 // MapCoords creates a new mesh by transforming all of the
 // coordinates according to the function f.
 func (m *Mesh) MapCoords(f func({{.coordType}}) {{.coordType}}) *Mesh {
-	mapping := NewCoordToCoord()
+	mapping := NewCoordMap[{{.coordType}}]()
 	if v2f := m.getVertexToFaceOrNil(); v2f != nil {
 		v2f.KeyRange(func(c {{.coordType}}) bool {
 			mapping.Store(c, f(c))
@@ -839,7 +839,7 @@ func (m *Mesh) Max() {{.coordType}} {
 	return result
 }
 
-func (m *Mesh) getVertexToFace() *CoordToFaces {
+func (m *Mesh) getVertexToFace() *CoordToSlice[*{{.faceType}}] {
 	v2f := m.getVertexToFaceOrNil()
 	if v2f != nil {
 		return v2f
@@ -857,7 +857,7 @@ func (m *Mesh) getVertexToFace() *CoordToFaces {
 		return v2f
 	}
 
-	v2f = NewCoordToFaces()
+	v2f = NewCoordToSlice[*{{.faceType}}]()
 	for f := range m.faces {
 		uniqueVertices(f, func(p {{.coordType}}) {
 			v2f.Append(p, f)
@@ -868,12 +868,12 @@ func (m *Mesh) getVertexToFace() *CoordToFaces {
 	return v2f
 }
 
-func (m *Mesh) getVertexToFaceOrNil() *CoordToFaces {
+func (m *Mesh) getVertexToFaceOrNil() *CoordToSlice[*{{.faceType}}] {
 	res := m.vertexToFace.Load()
 	if res == nil {
 		return nil
 	}
-	return res.(*CoordToFaces)
+	return res.(*CoordToSlice[*{{.faceType}}])
 }
 
 func (m *Mesh) clearVertexToFace() {

--- a/templates/solid.template
+++ b/templates/solid.template
@@ -104,23 +104,20 @@ func (j JoinedSolid) Contains(c {{.coordType}}) bool {
 // Optimize creates a version of the solid that is faster
 // when joining a large number of smaller solids.
 func (j JoinedSolid) Optimize() Solid {
-	bounders := make([]Bounder, len(j))
-	for i, s := range j {
-		bounders[i] = s
-	}
-	GroupBounders(bounders)
-	return groupedBoundersToSolid(bounders)
+	grouped := append([]Solid{}, j...)
+	GroupBounders(grouped)
+	return groupedSolidsToSolid(grouped)
 }
 
-func groupedBoundersToSolid(bs []Bounder) Solid {
-	if len(bs) == 1 {
-		return CacheSolidBounds(bs[0].(Solid))
+func groupedSolidsToSolid(s []Solid) Solid {
+	if len(s) == 1 {
+		return CacheSolidBounds(s[0].(Solid))
 	}
-	firstHalf := bs[:len(bs)/2]
-	secondHalf := bs[len(bs)/2:]
+	firstHalf := s[:len(s)/2]
+	secondHalf := s[len(s)/2:]
 	return CacheSolidBounds(JoinedSolid{
-		groupedBoundersToSolid(firstHalf),
-		groupedBoundersToSolid(secondHalf),
+		groupedSolidsToSolid(firstHalf),
+		groupedSolidsToSolid(secondHalf),
 	})
 }
 
@@ -553,8 +550,11 @@ func NewSolidMux(solids []Solid) *SolidMux {
 	if len(solids) == 0 {
 		return &SolidMux{}
 	}
-	bounders := make([]Bounder, len(solids))
-	bounderToIndex := map[Bounder]int{}
+	// Group Rects instead of Solids so that we know
+	// we can use the bounder as a key in a map to
+	// track the index.
+	bounders := make([]*Rect, len(solids))
+	bounderToIndex := map[*Rect]int{}
 	for i, s := range solids {
 		bounders[i] = BoundsRect(s)
 		bounderToIndex[bounders[i]] = i

--- a/templates/util_test.template
+++ b/templates/util_test.template
@@ -10,7 +10,7 @@ import (
 )
 
 type Failer interface {
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 }
 
 // ValidateMesh checks if m is manifold and has correct normals.

--- a/toolbox3d/color_func.go
+++ b/toolbox3d/color_func.go
@@ -67,7 +67,7 @@ func (c CoordColorFunc) Transform(t model3d.Transform) CoordColorFunc {
 // vertex that is part of a segment that changes color.
 func (c CoordColorFunc) ChangeFilterFunc(m *model3d.Mesh,
 	epsilon float64) func(c model3d.Coord3D) bool {
-	changed := model3d.NewCoordToBool()
+	changed := model3d.NewCoordMap[bool]()
 	m.Iterate(func(t *model3d.Triangle) {
 		for _, seg := range t.Segments() {
 			if c(seg[0]) != c(seg[1]) {
@@ -170,8 +170,8 @@ func JoinedMeshCoordColorFunc(meshToColorFunc map[*model3d.Mesh]any) CoordColorF
 //
 // The points argument is a collection of points that are
 // known to be within some solid. It may either be a slice
-// of points, a *CoordTree, or a *CoordToCoord returned by
-// model3d.MarchingCubesInterior.
+// of points, a *CoordTree, or a *CoordMap[Coord3D]
+// returned by model3d.MarchingCubesInterior.
 // It can also be nil, in which case no nearest neighbor
 // lookups are performed. Note that the color function will
 // panic() if no solid contains a given point or its
@@ -189,7 +189,7 @@ func JoinedSolidCoordColorFunc(points any, solidsAndColors ...any) CoordColorFun
 			coordTree = points
 		case []model3d.Coord3D:
 			coordTree = model3d.NewCoordTree(points)
-		case *model3d.CoordToCoord:
+		case *model3d.CoordMap[model3d.Coord3D]:
 			cs := make([]model3d.Coord3D, 0, points.Len())
 			points.ValueRange(func(c model3d.Coord3D) bool {
 				cs = append(cs, c)

--- a/toolbox3d/color_func.go
+++ b/toolbox3d/color_func.go
@@ -102,7 +102,7 @@ func ConstantCoordColorFunc(c render3d.Color) CoordColorFunc {
 // Pass a sequence of object, color, object, color, ...
 // where objects are *model3d.Mesh or model3d.SDF, and
 // colors are render3d.Color or CoordColorFunc.
-func JoinedCoordColorFunc(sdfsAndColors ...interface{}) CoordColorFunc {
+func JoinedCoordColorFunc(sdfsAndColors ...any) CoordColorFunc {
 	if len(sdfsAndColors)%2 != 0 {
 		panic("must pass an even number of arguments")
 	}
@@ -141,7 +141,7 @@ func JoinedCoordColorFunc(sdfsAndColors ...interface{}) CoordColorFunc {
 // choose the closest surface rather than the object with
 // the overall greatest SDF. This should only affect points
 // contained inside of the union of all of the objects.
-func JoinedMeshCoordColorFunc(meshToColorFunc map[*model3d.Mesh]interface{}) CoordColorFunc {
+func JoinedMeshCoordColorFunc(meshToColorFunc map[*model3d.Mesh]any) CoordColorFunc {
 	allMeshes := model3d.NewMesh()
 	triToColorFunc := map[*model3d.Triangle]CoordColorFunc{}
 	for mesh, colorObj := range meshToColorFunc {
@@ -181,7 +181,7 @@ func JoinedMeshCoordColorFunc(meshToColorFunc map[*model3d.Mesh]interface{}) Coo
 // points contained within one of the solids, a separate
 // set of interior points should be provided to use for
 // nearest neighbor lookup. This is the points argument.
-func JoinedSolidCoordColorFunc(points interface{}, solidsAndColors ...interface{}) CoordColorFunc {
+func JoinedSolidCoordColorFunc(points any, solidsAndColors ...any) CoordColorFunc {
 	var coordTree *model3d.CoordTree
 	if points != nil {
 		switch points := points.(type) {
@@ -238,7 +238,7 @@ func JoinedSolidCoordColorFunc(points interface{}, solidsAndColors ...interface{
 	}
 }
 
-func colorFuncFromObj(obj interface{}) CoordColorFunc {
+func colorFuncFromObj(obj any) CoordColorFunc {
 	switch colorFn := obj.(type) {
 	case CoordColorFunc:
 		return colorFn

--- a/toolbox3d/height_map.go
+++ b/toolbox3d/height_map.go
@@ -473,8 +473,8 @@ func separateSingularVertices(m *model3d.Mesh) {
 	}
 }
 
-func findUnsharedEdges(m *model3d.Mesh) *model3d.EdgeToBool {
-	edges := model3d.NewEdgeToBool()
+func findUnsharedEdges(m *model3d.Mesh) *model3d.EdgeMap[bool] {
+	edges := model3d.NewEdgeMap[bool]()
 	m.Iterate(func(t *model3d.Triangle) {
 		for i := 0; i < 3; i++ {
 			p1 := t[i]


### PR DESCRIPTION
* [x] Use `any` instead of `interface{}`
* [x] GroupBounders() should be a generic method; find places that inconveniently cast right now
* [x] Various fast_maps.template implementations should be generic instead of using `interface{}`